### PR TITLE
Create budgets without the CAF

### DIFF
--- a/terraform-azure-lz-project-set/README.md
+++ b/terraform-azure-lz-project-set/README.md
@@ -30,6 +30,7 @@ For each environment, the module will create a subscription, a network resource 
 
 | Name | Type |
 |------|------|
+| [azurerm_consumption_budget_subscription.subscription_budget](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/consumption_budget_subscription) | resource |
 | [azurerm_management_group.project_set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group) | resource |
 | [azurerm_management_group.landing_zones](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/management_group) | data source |
 

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -66,10 +66,7 @@ module "lz_vending" {
 
 # Create budgets directly using azurerm provider instead of the lz-vending module
 resource "azurerm_consumption_budget_subscription" "subscription_budget" {
-  for_each = {
-    for k, v in var.subscriptions : k => v
-    if v.budget_amount > 0
-  }
+  for_each = var.subscriptions
 
   name            = "budget-${var.license_plate}-${each.value.name}"
   subscription_id = module.lz_vending[each.key].subscription_id
@@ -82,7 +79,7 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
   }
 
   notification {
-    enabled        = true
+    enabled        = each.value.budget_amount > 0
     threshold      = 80.0
     operator       = "GreaterThanOrEqualTo"
     threshold_type = "Actual"
@@ -91,7 +88,7 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
   }
 
   notification {
-    enabled        = true
+    enabled        = each.value.budget_amount > 0
     threshold      = 100.0
     operator       = "GreaterThan"
     threshold_type = "Forecasted"

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -68,7 +68,7 @@ module "lz_vending" {
 resource "azurerm_consumption_budget_subscription" "subscription_budget" {
   for_each = var.subscriptions
 
-  name            = "budget-${var.license_plate}-${each.value.name}"
+  name            = "budget-for-${var.license_plate}-${each.value.name}-from-product-registry"
   subscription_id = module.lz_vending[each.key].subscription_resource_id
 
   amount     = each.value.budget_amount

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
   for_each = var.subscriptions
 
   name            = "budget-${var.license_plate}-${each.value.name}"
-  subscription_id = module.lz_vending[each.key].subscription_id
+  subscription_id = module.lz_vending[each.key].subscription_resource_id
 
   amount     = each.value.budget_amount
   time_grain = "Monthly"


### PR DESCRIPTION
## Problem
The current CAF budget implementation using AZAPI is causing issues:
- A start date must be provided but can't be changed once set
- We currently provide the current time as the start date
- There's no way to track the originally set start date
- AZAPI doesn't support "destroy on recreate", causing failures when trying to update budgets

## Solution
Replace CAF budgets with a custom implementation using the azurerm provider:
- Create budgets directly using azurerm resources
- Implement lifecycle ignore specifically for the `time_period`
  - This allows us to update other budget parameters without recreating the entire budget
- Gain more control over budget creation and management

## Impact
- Resolves the current limitations in budget updates, regarding start dates
- Provides a more flexible and maintainable approach to Azure budget management
- Eliminates failures caused by AZAPI's lack of "destroy on recreate" functionality

## Implementation
Update relevant Terraform modules to use `azurerm_consumption_budget_subscription` instead of the CAF budget module, applying lifecycle ignore to the `time_period` parameter.