### PR TITLE
Tag Inheritance Value Property Casing Fix

### DIFF
--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_inherit_subscription_tags.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_inherit_subscription_tags.json
@@ -8,7 +8,7 @@
     "notScopes": [],
     "parameters": {
       "InheritTag-Account-Coding": {
-        "Value": "account_coding"
+        "value": "account_coding"
       },
       "InheritTag-Billing-Group": {
         "value": "billing_group"


### PR DESCRIPTION
Fixed the casing in the `value` property