### PR TITLE
Deploy-VMSS-Monitoring policy config

### DIFF
--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -6,11 +6,11 @@ locals {
           logAnalyticsWorkspaceIdforVMReporting                  = "/subscriptions/${var.subscription_id_management}/resourceGroups/${var.root_id}-mgmt/providers/Microsoft.OperationalInsights/workspaces/${var.root_id}-la",
           listOfMembersToExcludeFromWindowsVMAdministratorsGroup = "",
           listOfMembersToIncludeInWindowsVMAdministratorsGroup   = ""
-        },
+        }
         Deploy-Private-DNS-Sql = {
           privateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.database.windows.net",
-        },
-      },
+        }
+      }
       access_control = {}
     }
     landing-zones = {
@@ -20,7 +20,7 @@ locals {
         }
         Deny-RSG-Locations = {
           listOfAllowedLocations = [var.primary_location, var.secondary_location]
-        },
+        }
         Deploy-VMSS-Monitoring = {
           scopeToSupportedImages = true
         }

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -7,10 +7,10 @@ locals {
           listOfMembersToExcludeFromWindowsVMAdministratorsGroup = "",
           listOfMembersToIncludeInWindowsVMAdministratorsGroup   = ""
         },
-        "Deploy-Private-DNS-Sql" = {
+        Deploy-Private-DNS-Sql = {
           privateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.database.windows.net",
         },
-      }
+      },
       access_control = {}
     }
     landing-zones = {
@@ -20,6 +20,9 @@ locals {
         }
         Deny-RSG-Locations = {
           listOfAllowedLocations = [var.primary_location, var.secondary_location]
+        },
+        Deploy-VMSS-Monitoring = {
+          scopeToSupportedImages = true
         }
       }
       access_control = {}


### PR DESCRIPTION
This Azure policy setting `Deploy-VMSS-Monitoring` with `scopeToSupportedImages = true` is used to control the deployment of monitoring on Virtual Machine Scale Sets (VMSS) in Azure.

When you set `scopeToSupportedImages = true`, the policy will:

1. Only deploy monitoring agents to VMSS instances that are running supported OS images
2. Skip deployment attempts on unsupported images, preventing errors and failed deployments
3. Help maintain efficient resource usage by not attempting to install monitoring on incompatible systems

This is particularly useful because:
- It prevents deployment failures on unsupported OS images
- Reduces unnecessary policy evaluation overhead
- Helps maintain a cleaner compliance state since the policy won't try to enforce monitoring on incompatible systems
- Avoids potential issues that could arise from attempting to install monitoring agents on unsupported platforms

Without this setting (if it were `false`), the policy would attempt to deploy monitoring to all VMSS instances regardless of OS compatibility, which could lead to deployment failures and unnecessary overhead.