### PR TITLE
Remove PowerBI Private DNS Zone Link

### DIFF
--- a/caf_cccs_medium/modules/connectivity/settings.connectivity.tf
+++ b/caf_cccs_medium/modules/connectivity/settings.connectivity.tf
@@ -186,7 +186,7 @@ locals {
             azure_web_apps_sites                 = true
             azure_web_apps_static_sites          = true
             cognitive_services_account           = true
-            microsoft_power_bi                   = true
+            microsoft_power_bi                   = false # NOTE: Set to false, due to the following GitHub Issue: https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/1212
             signalr                              = true
             signalr_webpubsub                    = true
             storage_account_blob                 = true


### PR DESCRIPTION
This pull request includes a small change to the `caf_cccs_medium/modules/connectivity/settings.connectivity.tf` file. The change sets `microsoft_power_bi` to false due to an ongoing issue tracked in a GitHub issue.

* [`caf_cccs_medium/modules/connectivity/settings.connectivity.tf`](diffhunk://#diff-4bef7e0aac64b545e9d20c6ca0059068b00443584520b3f5741ad23cd5a34ca3L189-R189): Set `microsoft_power_bi` to false due to GitHub Issue #1212.