### PR TITLE
Corrected Diagnostics protection policy

### DIFF
--- a/caf_cccs_medium/README.md
+++ b/caf_cccs_medium/README.md
@@ -161,7 +161,7 @@ Policies are applied in the "Default" mode. It should be possible to provide [ov
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_VNet-DNS-Settings"></a> [VNet-DNS-Settings](#input\_VNet-DNS-Settings) | Sets the VNet DNS settings for the policy assignment. | `list` | n/a | yes |
+| <a name="input_VNet-DNS-Settings"></a> [VNet-DNS-Settings](#input\_VNet-DNS-Settings) | Sets the VNet DNS settings for the policy assignment. | `list(any)` | n/a | yes |
 | <a name="input_application_id"></a> [application\_id](#input\_application\_id) | (Optional) The object ID of an Application in Azure Active Directory. | `string` | `null` | no |
 | <a name="input_auto_learn_private_ranges_enabled"></a> [auto\_learn\_private\_ranges\_enabled](#input\_auto\_learn\_private\_ranges\_enabled) | (Optional) Whether enable auto learn private IP range. | `bool` | `null` | no |
 | <a name="input_base_firewall_policy_name"></a> [base\_firewall\_policy\_name](#input\_base\_firewall\_policy\_name) | (Required) The name which should be used for the parent Firewall Policy. | `string` | n/a | yes |

--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
@@ -51,9 +51,6 @@
         },
         "Deny-New-VNet-Peerings": {
           "effect": "SET using local.archetype_config_overrides"
-        },
-        "Deny-Delete-Diagnostics": {
-          "effect": "SET using local.archetype_config_overrides"
         }
       },
       "access_control": {}

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -42,9 +42,6 @@ locals {
         },
         Deny-New-VNet-Peerings = {
           effect = var.policy_effect
-        },
-        Deny-Delete-Diagnostics = {
-          effect = var.policy_effect
         }
       }
       access_control = {}


### PR DESCRIPTION
This pull request includes changes to the `caf_cccs_medium` module to remove the `Deny-Delete-Diagnostics` policy. The most important changes are:

Policy removal:

* [`caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json`](diffhunk://#diff-1793ace63156162ac6f68e852ccaefbe296954a103535746a486a9fc4a19fde7L54-L56): Removed the `Deny-Delete-Diagnostics` policy from the list of policies.
* [`caf_cccs_medium/modules/core/settings.core.tf`](diffhunk://#diff-ccc9dcaf2365b28061da119066bb58b80b0ecfb206638ee50e06a87c8584c7c2L45-L47): Removed the `Deny-Delete-Diagnostics` policy from the `locals` block.