### PR TITLE
DINE policy for private dns postgresql flex-server

### DIFF
--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
@@ -6,6 +6,7 @@
       "Deploy-Private-DNS-Zones",
       "Deploy-Private-DNS-Sql",
       "Deploy-Private-DNS-OAI",
+      "Deploy-Private-DNS-PSQL",
       "MicrosoftCISv2",
       "NIST-SP-800-53-Rev5"
     ],
@@ -36,6 +37,9 @@
           "FirewallLogAnalyticsDestinationType": "Dedicated"
         },
         "Deploy-Private-DNS-Sql": {
+          "privateDnsZoneId": "SET using local.archetype_config_overrides"
+        },
+        "Deploy-Private-DNS-PSQL": {
           "privateDnsZoneId": "SET using local.archetype_config_overrides"
         },
         "Deploy-Private-DNS-OAI": {

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_private_dns_postgresql_server.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_private_dns_postgresql_server.json
@@ -1,0 +1,34 @@
+{
+    "name": "Deploy-Private-DNS-PSQL",
+    "type": "Microsoft.Authorization/policyAssignments",
+    "apiVersion": "2024-04-01",
+    "properties": {
+      "displayName": "Deploy Private DNS PostgreSQL-Flexible Server",
+      "description": "Deploys private dns for postgresql flexible server instances",
+      "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Private-DNS-Generic",
+      "metadata": {},
+      "scope": "${current_scope_resource_id}",
+      "notScopes": [],
+      "parameters": {
+        "privateDnsZoneId": {
+          "value": "privateDnsZoneId"
+        },
+        "location": {
+          "value": "location"
+        },
+        "resourceType": {
+          "value": "Microsoft.DBforPostgreSQL/flexibleServers"
+        },
+        "groupId": {
+          "value": "postgresqlServer"
+        }
+      },
+      "enforcementMode": "Default",
+      "overrides": []
+    },
+    "location": "${default_location}",
+    "identity": {
+      "type": "SystemAssigned"
+    }
+  }
+  

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -16,7 +16,7 @@ locals {
           openaiPrivateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.openai.azure.com"
         }
         Deploy-Private-DNS-PSQL = {
-          privateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.postgres.database.windows.com",
+          privateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.postgres.database.azure.com",
           location : var.primary_location,
         }
       }

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -15,6 +15,10 @@ locals {
           defaultPrivateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.cognitiveservices.azure.com",
           openaiPrivateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.openai.azure.com"
         }
+        Deploy-Private-DNS-PSQL = {
+          privateDnsZoneId : "/subscriptions/${var.subscription_id_connectivity}/resourceGroups/${var.root_id}-dns/providers/Microsoft.Network/privateDnsZones/privatelink.postgres.database.windows.com",
+          location : var.primary_location,
+        }
       }
       access_control = {}
     }


### PR DESCRIPTION
This Azure  Deploy If Not Exist custom policy for Private DNS Zone for PostgreSQL flexible server will create DNS A-Record privatelink.postgres.database.windows.com