### PR TITLE
Add Azure AD Groups module for role-based access control

### DIFF
--- a/azure_ad_groups/README.md
+++ b/azure_ad_groups/README.md
@@ -1,0 +1,45 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azuread_group.groups](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group) | resource |
+| [azuread_group_member.group_members](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group_member) | resource |
+| [azurerm_role_assignment.group_roles](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
+| [azuread_user.users](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_email"></a> [admin\_email](#input\_admin\_email) | Email of the admin user who will be an owner of all groups | `string` | n/a | yes |
+| <a name="input_contributors"></a> [contributors](#input\_contributors) | List of email addresses for users who should be in the Contributors group | `list(string)` | `[]` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., Forge, Prod) | `string` | n/a | yes |
+| <a name="input_license_plate"></a> [license\_plate](#input\_license\_plate) | License plate identifier for the project | `string` | n/a | yes |
+| <a name="input_owners"></a> [owners](#input\_owners) | List of email addresses for users who should be in the Owners group | `list(string)` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of the project | `string` | n/a | yes |
+| <a name="input_readers"></a> [readers](#input\_readers) | List of email addresses for users who should be in the Readers group | `list(string)` | `[]` | no |
+| <a name="input_scope"></a> [scope](#input\_scope) | The scope at which the role assignments should be created | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_groups"></a> [groups](#output\_groups) | Map of created Azure AD groups |
+<!-- END_TF_DOCS -->

--- a/azure_ad_groups/main.tf
+++ b/azure_ad_groups/main.tf
@@ -1,0 +1,93 @@
+locals {
+  groups = {
+    owners = {
+      name        = "DO_PuC_Azure_${title(var.environment)}_${var.license_plate}_Owners"
+      description = "Owners group for ${var.project_name} project set in Azure ${title(var.environment)} LZ"
+      role        = "Owner"
+      members     = var.owners
+    }
+    contributors = {
+      name        = "DO_PuC_Azure_${title(var.environment)}_${var.license_plate}_Contributors"
+      description = "Contributors group for ${var.project_name} project set in Azure ${title(var.environment)} LZ"
+      role        = "Contributor"
+      members     = var.contributors
+    }
+    readers = {
+      name        = "DO_PuC_Azure_${title(var.environment)}_${var.license_plate}_Readers"
+      description = "Readers group for ${var.project_name} project set in Azure ${title(var.environment)} LZ"
+      role        = "Reader"
+      members     = var.readers
+    }
+  }
+}
+
+# Get the current client configuration
+data "azuread_client_config" "current" {}
+
+# Get user objects
+data "azuread_user" "users" {
+  for_each            = toset(flatten([for group in local.groups : group.members]))
+  user_principal_name = each.key
+}
+
+# Create the groups
+resource "azuread_group" "groups" {
+  for_each         = local.groups
+  display_name     = each.value.name
+  security_enabled = true
+  description      = each.value.description
+  owners = compact([
+    try(data.azuread_user.users[var.admin_email].object_id, null),
+    data.azuread_client_config.current.object_id
+  ])
+}
+
+# Add users to groups
+resource "azuread_group_member" "group_members" {
+  for_each = {
+    for item in flatten([
+      for group_key, group in local.groups : [
+        for member in group.members : {
+          group_key = group_key
+          member    = member
+        }
+      ]
+    ]) : "${item.group_key}-${item.member}" => item
+  }
+
+  group_object_id  = azuread_group.groups[each.value.group_key].id
+  member_object_id = data.azuread_user.users[each.value.member].object_id
+}
+
+# Assign roles to groups
+resource "azurerm_role_assignment" "group_roles" {
+  for_each             = local.groups
+  scope                = var.scope
+  role_definition_name = each.value.role
+  principal_id         = azuread_group.groups[each.key].object_id
+  description          = "${var.license_plate} ${each.value.role} Group Assignment"
+
+  condition_version = each.value.role == "Owner" ? "2.0" : null
+  condition = each.value.role == "Owner" ? (<<EOT
+(
+ (
+  !(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})
+ )
+ OR
+ (
+  @Request[Microsoft.Authorization/roleAssignments:PrincipalType] StringEquals 'ServicePrincipal'
+ )
+)
+AND
+(
+ (
+  !(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})
+ )
+ OR
+ (
+  @Resource[Microsoft.Authorization/roleAssignments:PrincipalType] StringEquals 'ServicePrincipal'
+ )
+)
+EOT
+  ) : null
+}

--- a/azure_ad_groups/outputs.tf
+++ b/azure_ad_groups/outputs.tf
@@ -1,0 +1,10 @@
+output "groups" {
+  description = "Map of created Azure AD groups"
+  value = {
+    for k, v in azuread_group.groups : k => {
+      id           = v.id
+      object_id    = v.object_id
+      display_name = v.display_name
+    }
+  }
+} 

--- a/azure_ad_groups/variables.tf
+++ b/azure_ad_groups/variables.tf
@@ -1,0 +1,41 @@
+variable "environment" {
+  type        = string
+  description = "Environment name (e.g., Forge, Prod)"
+}
+
+variable "license_plate" {
+  type        = string
+  description = "License plate identifier for the project"
+}
+
+variable "project_name" {
+  type        = string
+  description = "Name of the project"
+}
+
+variable "scope" {
+  type        = string
+  description = "The scope at which the role assignments should be created"
+}
+
+variable "admin_email" {
+  type        = string
+  description = "Email of the admin user who will be an owner of all groups"
+}
+
+variable "owners" {
+  type        = list(string)
+  description = "List of email addresses for users who should be in the Owners group"
+}
+
+variable "contributors" {
+  type        = list(string)
+  default     = []
+  description = "List of email addresses for users who should be in the Contributors group"
+}
+
+variable "readers" {
+  type        = list(string)
+  default     = []
+  description = "List of email addresses for users who should be in the Readers group"
+} 


### PR DESCRIPTION
# Azure AD Group Management Module Update

This PR implements an Azure AD group management module that creates and manages three security groups (Owners, Contributors, Readers) with corresponding role assignments.

## Changes
- Created security groups with standardized naming convention following DO_PuC_Azure pattern
- Implemented role assignments with conditional access policies for Owners to restrict role management to Service Principals
- Added group membership management with dynamic user lookup
- Included admin user as group owner alongside service principal for administrative access
- Standardized group descriptions and naming across environments
- Added output map of created groups for reference in dependent modules

## Notes
- Groups follow the tenant standard naming convention with environment and license plate identifiers
- Owner role assignments include conditions to prevent privilege escalation
- All groups are security-enabled and support dynamic membership updates
