### PR TITLE
Fixed GH Org in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # CODEOWNER reference examples: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
 
-* @bcgov-c/public-cloud-team-azure-devs
+* @bcgov/public-cloud-team-azure-devs


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change corrects the team handle for the public cloud team.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L3-R3): Updated the team handle from `@bcgov-c/public-cloud-team-azure-devs` to `@bcgov/public-cloud-team-azure-devs`.