### PR TITLE
Refactor azuread_group_member iteration to use a set for unique members

### DIFF
--- a/azure_ad_groups/main.tf
+++ b/azure_ad_groups/main.tf
@@ -47,7 +47,7 @@ resource "azuread_group_member" "group_members" {
   for_each = {
     for item in flatten([
       for group_key, group in local.groups : [
-        for member in group.members : {
+        for member in toset(group.members) : {
           group_key = group_key
           member    = member
         }


### PR DESCRIPTION
- Refactor group member iteration to use a set for unique members in azuread_group_member resource
- This is required when the same person is a PO and a TL