### PR TITLE
Azure Policy for Denying VNet Address Space Changes

### DIFF
--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
@@ -13,7 +13,9 @@
       "Deny-New-VNet-Peerings",
       "Deny-Delete-Diagnostics"
     ],
-    "policy_definitions": [],
+    "policy_definitions": [
+      "Deny-VNet-Address-Changes"
+    ],
     "policy_set_definitions": [],
     "role_definitions": [],
     "archetype_config": {

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_vnet_address_space_changes.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_vnet_address_space_changes.json
@@ -1,0 +1,63 @@
+{
+  "name": "Deny-VNet-Address-Changes",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "apiVersion": "2024-05-01",
+  "scope": null,
+  "properties": {
+    "displayName": "Deny changing address space of a Virtual Network",
+    "description": "This Policy will prevent users from changing the Address Space on a VNet",
+    "policyType": "Custom",
+    "mode": "All",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Networking"
+    },
+    "parameters": {
+      "addressSpaceSettings": {
+        "type": "Array",
+        "metadata": {
+          "displayname": "Enforced Address Space Settings",
+          "description": "Users will be unable to change the address space on a VNet from the values defined in this array."
+        }
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/virtualNetworks"
+          },
+          {
+            "anyOf": [
+              {
+                "value": "[if(empty(field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes')), bool('false'), equals(length(intersection(parameters('addressSpaceSettings'), field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes'))), length(parameters('addressSpaceSettings'))))]",
+                "equals": false
+              },
+              {
+                "value": "[if(empty(field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes')), bool('false'), equals(length(field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes')),length(parameters('addressSpaceSettings'))))]",
+                "equals": false
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new policy definition to prevent changes to the address space of a Virtual Network (VNet). The changes include updating the `archetype_extension_es_landing_zones` template and adding a new policy definition file.

Key changes:

### Policy Definition Updates:

* Added a new policy definition `Deny-VNet-Address-Changes` to the `policy_definitions` array in the `archetype_extension_es_landing_zones.tmpl.json` file.
* Created a new file `policy_definition_deny_vnet_address_space_changes.json` that defines the `Deny-VNet-Address-Changes` policy, which prevents users from changing the address space on a VNet.