### PR TITLE
Private DNS Resolver Terraform Provider Updates to v4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNER reference examples: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+* @bcgov/public-cloud-team-azure-devs

--- a/azure_private_dns/private_dns_resolver/README.md
+++ b/azure_private_dns/private_dns_resolver/README.md
@@ -5,14 +5,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.8.0, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.112.0, < 4.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=3.112.0, < 4.0.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
 
 ## Modules
 

--- a/azure_private_dns/private_dns_resolver/locals.tf
+++ b/azure_private_dns/private_dns_resolver/locals.tf
@@ -2,7 +2,6 @@ locals {
   subnets = {
     for subnet in var.virtual_network_object.subnet : subnet.name => merge(
       subnet, {
-        # first_available_ip = cidrhost(subnet.address_prefixes, 4)
         first_available_ip = cidrhost(element(subnet.address_prefixes, 0), 4)
         # This extracts the fourth IP address from the subnet address prefix, which is the first available IP address in the subnet (as Azure reserves the first three IP addresses in each subnet)
       }

--- a/azure_private_dns/private_dns_resolver/locals.tf
+++ b/azure_private_dns/private_dns_resolver/locals.tf
@@ -2,7 +2,8 @@ locals {
   subnets = {
     for subnet in var.virtual_network_object.subnet : subnet.name => merge(
       subnet, {
-        first_available_ip = cidrhost(subnet.address_prefixes, 4)
+        # first_available_ip = cidrhost(subnet.address_prefixes, 4)
+        first_available_ip = cidrhost(element(subnet.address_prefixes, 0), 4)
         # This extracts the fourth IP address from the subnet address prefix, which is the first available IP address in the subnet (as Azure reserves the first three IP addresses in each subnet)
       }
     )

--- a/azure_private_dns/private_dns_resolver/locals.tf
+++ b/azure_private_dns/private_dns_resolver/locals.tf
@@ -2,7 +2,7 @@ locals {
   subnets = {
     for subnet in var.virtual_network_object.subnet : subnet.name => merge(
       subnet, {
-        first_available_ip = cidrhost(subnet.address_prefix, 4)
+        first_available_ip = cidrhost(subnet.address_prefixes, 4)
         # This extracts the fourth IP address from the subnet address prefix, which is the first available IP address in the subnet (as Azure reserves the first three IP addresses in each subnet)
       }
     )

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_dns_forwarding_ruleset.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_dns_forwarding_ruleset.tf
@@ -6,6 +6,8 @@ resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "this" {
     azurerm_private_dns_resolver_outbound_endpoint.this.id
   ]
 
+  tags = {}
+
   lifecycle {
     ignore_changes = [
       tags

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_dns_forwarding_ruleset.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_dns_forwarding_ruleset.tf
@@ -6,8 +6,6 @@ resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "this" {
     azurerm_private_dns_resolver_outbound_endpoint.this.id
   ]
 
-  tags = {}
-
   lifecycle {
     ignore_changes = [
       tags

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_dns_forwarding_ruleset.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_dns_forwarding_ruleset.tf
@@ -5,4 +5,10 @@ resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "this" {
   private_dns_resolver_outbound_endpoint_ids = [
     azurerm_private_dns_resolver_outbound_endpoint.this.id
   ]
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_forwarding_rule.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_forwarding_rule.tf
@@ -14,7 +14,9 @@ resource "azurerm_private_dns_resolver_forwarding_rule" "this" {
     port       = 53
   }
 
-  # metadata = {
-  #   key = "value"
-  # }
+  lifecycle {
+    ignore_changes = [
+      metadata
+    ]
+  }
 }

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_forwarding_rule.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_forwarding_rule.tf
@@ -14,6 +14,7 @@ resource "azurerm_private_dns_resolver_forwarding_rule" "this" {
     port       = 53
   }
 
+  metadata = {}
   lifecycle {
     ignore_changes = [
       metadata

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_forwarding_rule.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_forwarding_rule.tf
@@ -14,7 +14,6 @@ resource "azurerm_private_dns_resolver_forwarding_rule" "this" {
     port       = 53
   }
 
-  metadata = {}
   lifecycle {
     ignore_changes = [
       metadata

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_outbound_endpoint.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_outbound_endpoint.tf
@@ -4,4 +4,10 @@ resource "azurerm_private_dns_resolver_outbound_endpoint" "this" {
   location                = azurerm_private_dns_resolver.this.location
 
   subnet_id = local.subnets["outbound_endpoint"].id
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_outbound_endpoint.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_outbound_endpoint.tf
@@ -5,8 +5,6 @@ resource "azurerm_private_dns_resolver_outbound_endpoint" "this" {
 
   subnet_id = local.subnets["outbound_endpoint"].id
 
-  tags = {}
-
   lifecycle {
     ignore_changes = [
       tags

--- a/azure_private_dns/private_dns_resolver/private_dns_resolver_outbound_endpoint.tf
+++ b/azure_private_dns/private_dns_resolver/private_dns_resolver_outbound_endpoint.tf
@@ -5,6 +5,8 @@ resource "azurerm_private_dns_resolver_outbound_endpoint" "this" {
 
   subnet_id = local.subnets["outbound_endpoint"].id
 
+  tags = {}
+
   lifecycle {
     ignore_changes = [
       tags

--- a/azure_private_dns/private_dns_resolver/provider.tf
+++ b/azure_private_dns/private_dns_resolver/provider.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">=1.8.0, < 2.0.0"
+  required_version = ">=1.9.0, < 2.0.0"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.112.0, < 4.0.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/azure_private_dns/virtual_network/README.md
+++ b/azure_private_dns/virtual_network/README.md
@@ -39,7 +39,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_IPAM_TOKEN"></a> [IPAM\_TOKEN](#input\_IPAM\_TOKEN) | (Required) The IPAM token to use for IP address management. | `string` | n/a | yes |
-| <a name="input_environment"></a> [environment](#input\_environment) | This is either LIVE or FORGE. | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | (Required) This is either LIVE or FORGE. | `string` | n/a | yes |
 | <a name="input_firewall_private_ip_address"></a> [firewall\_private\_ip\_address](#input\_firewall\_private\_ip\_address) | (Required) Private IP address of the Azure Firewall to connect to. | `list(string)` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Azure region to deploy to. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_private_dns_resolver_virtual_network_name"></a> [private\_dns\_resolver\_virtual\_network\_name](#input\_private\_dns\_resolver\_virtual\_network\_name) | (Required) Name of the Virtual Network to deploy the Private DNS Resolver into. | `string` | n/a | yes |

--- a/azure_private_dns/virtual_network/README.md
+++ b/azure_private_dns/virtual_network/README.md
@@ -7,14 +7,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.0 |
-| <a name="requirement_azureipam"></a> [azureipam](#requirement\_azureipam) | 1.0.1 |
+| <a name="requirement_azureipam"></a> [azureipam](#requirement\_azureipam) | ~> 1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azureipam"></a> [azureipam](#provider\_azureipam) | 1.0.1 |
+| <a name="provider_azureipam"></a> [azureipam](#provider\_azureipam) | ~> 1.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
 
 ## Modules
@@ -25,7 +25,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azureipam_reservation.private_dns_resolver](https://registry.terraform.io/providers/XtratusCloud/azureipam/1.0.1/docs/resources/reservation) | resource |
+| [azureipam_reservation.private_dns_resolver](https://registry.terraform.io/providers/XtratusCloud/azureipam/latest/docs/resources/reservation) | resource |
 | [azurerm_network_security_group.inbound_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
 | [azurerm_network_security_group.outbound_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/azure_private_dns/virtual_network/README.md
+++ b/azure_private_dns/virtual_network/README.md
@@ -5,17 +5,17 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.8.0, < 2.0.0 |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 1.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.0 |
 | <a name="requirement_azureipam"></a> [azureipam](#requirement\_azureipam) | 1.0.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.112.0, < 4.0.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azureipam"></a> [azureipam](#provider\_azureipam) | 1.0.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=3.112.0, < 4.0.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
 
 ## Modules
 

--- a/azure_private_dns/virtual_network/ipam.tf
+++ b/azure_private_dns/virtual_network/ipam.tf
@@ -1,6 +1,7 @@
 resource "azureipam_reservation" "private_dns_resolver" {
   space       = "bcgov-managed-lz-${lower(var.environment)}"
-  blocks       = ["bcgov-managed-lz-${lower(var.environment)}"]
+  # blocks       = ["bcgov-managed-lz-${lower(var.environment)}"]
+  block       = "bcgov-managed-lz-${lower(var.environment)}"
   size        = 23 # NOTE: Two /24 subnets are required for the Azure Private DNS Resolvers (https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview#virtual-network-restrictions)
   description = "Azure Private DNS Resolvers"
 }

--- a/azure_private_dns/virtual_network/ipam.tf
+++ b/azure_private_dns/virtual_network/ipam.tf
@@ -1,5 +1,5 @@
 resource "azureipam_reservation" "private_dns_resolver" {
-  space       = "bcgov-managed-lz-${lower(var.environment)}"
+  space = "bcgov-managed-lz-${lower(var.environment)}"
   # blocks       = ["bcgov-managed-lz-${lower(var.environment)}"]
   block       = "bcgov-managed-lz-${lower(var.environment)}"
   size        = 23 # NOTE: Two /24 subnets are required for the Azure Private DNS Resolvers (https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview#virtual-network-restrictions)

--- a/azure_private_dns/virtual_network/ipam.tf
+++ b/azure_private_dns/virtual_network/ipam.tf
@@ -1,6 +1,6 @@
 resource "azureipam_reservation" "private_dns_resolver" {
   space       = "bcgov-managed-lz-${lower(var.environment)}"
-  block       = "bcgov-managed-lz-${lower(var.environment)}"
+  blocks       = ["bcgov-managed-lz-${lower(var.environment)}"]
   size        = 23 # NOTE: Two /24 subnets are required for the Azure Private DNS Resolvers (https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview#virtual-network-restrictions)
   description = "Azure Private DNS Resolvers"
 }

--- a/azure_private_dns/virtual_network/ipam.tf
+++ b/azure_private_dns/virtual_network/ipam.tf
@@ -1,6 +1,6 @@
 resource "azureipam_reservation" "private_dns_resolver" {
   space = "bcgov-managed-lz-${lower(var.environment)}"
-  # blocks       = ["bcgov-managed-lz-${lower(var.environment)}"]
+  # blocks       = ["bcgov-managed-lz-${lower(var.environment)}"] # NOTE: This is for v2.x of IPAM, which currently throws an error. See: https://github.com/XtratusCloud/terraform-provider-azureipam/issues/21
   block       = "bcgov-managed-lz-${lower(var.environment)}"
   size        = 23 # NOTE: Two /24 subnets are required for the Azure Private DNS Resolvers (https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview#virtual-network-restrictions)
   description = "Azure Private DNS Resolvers"

--- a/azure_private_dns/virtual_network/provider.tf
+++ b/azure_private_dns/virtual_network/provider.tf
@@ -28,6 +28,7 @@ provider "azurerm" {
 
 provider "azapi" {
   skip_provider_registration = false
+  enable_preflight           = true
 }
 
 provider "azureipam" {

--- a/azure_private_dns/virtual_network/provider.tf
+++ b/azure_private_dns/virtual_network/provider.tf
@@ -14,7 +14,7 @@ terraform {
 
     azureipam = {
       source  = "XtratusCloud/azureipam"
-      version = "~> 2.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/azure_private_dns/virtual_network/provider.tf
+++ b/azure_private_dns/virtual_network/provider.tf
@@ -14,7 +14,7 @@ terraform {
 
     azureipam = {
       source  = "XtratusCloud/azureipam"
-      version = "1.0.1"
+      version = "~> 2.0"
     }
   }
 }

--- a/azure_private_dns/virtual_network/provider.tf
+++ b/azure_private_dns/virtual_network/provider.tf
@@ -1,15 +1,15 @@
 terraform {
-  required_version = ">=1.8.0, < 2.0.0"
+  required_version = ">=1.9.0, < 2.0.0"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.112.0, < 4.0.0"
+      version = "~> 4.0"
     }
 
     azapi = {
       source  = "azure/azapi"
-      version = "~> 1.13"
+      version = "~> 2.0"
     }
 
     azureipam = {

--- a/azure_private_dns/virtual_network/variables.tf
+++ b/azure_private_dns/virtual_network/variables.tf
@@ -7,7 +7,7 @@ variable "IPAM_TOKEN" {
 }
 
 variable "environment" {
-  description = "This is either LIVE or FORGE."
+  description = "(Required) This is either LIVE or FORGE."
   type        = string
 
   validation {

--- a/azure_private_dns/virtual_network/vhub_connection.tf
+++ b/azure_private_dns/virtual_network/vhub_connection.tf
@@ -4,4 +4,8 @@ resource "azurerm_virtual_hub_connection" "this" {
   remote_virtual_network_id = azurerm_virtual_network.this.id
 
   internet_security_enabled = true #TODO: Update this to be a variable, which will require updating the consuming modules
+
+  routing {
+    static_vnet_propagate_static_routes_enabled = true
+  }
 }

--- a/azure_private_dns/virtual_network/vhub_connection.tf
+++ b/azure_private_dns/virtual_network/vhub_connection.tf
@@ -5,7 +5,9 @@ resource "azurerm_virtual_hub_connection" "this" {
 
   internet_security_enabled = true #TODO: Update this to be a variable, which will require updating the consuming modules
 
-  routing {
-    static_vnet_propagate_static_routes_enabled = true
+  lifecycle {
+    ignore_changes = [
+      routing
+    ]
   }
 }

--- a/azure_private_dns/virtual_network/vnet.tf
+++ b/azure_private_dns/virtual_network/vnet.tf
@@ -61,6 +61,7 @@ resource "azurerm_virtual_network" "this" {
   dns_servers = var.firewall_private_ip_address
 
   # NOTE: We are using the cidrsubnet() function, and offsetting the bit position by 1, since the parent CIDR is /23 (and we need to split it into two /24s)
+  # IMPORTANT: The subnet property changed in azurerm 4.1.0 from `address_prefix` to `address_prefixes`
   subnet {
     name             = "inbound_endpoint"
     address_prefixes = [cidrsubnet(azureipam_reservation.private_dns_resolver.cidr, 1, 0)]

--- a/azure_private_dns/virtual_network/vnet.tf
+++ b/azure_private_dns/virtual_network/vnet.tf
@@ -58,7 +58,8 @@ resource "azurerm_virtual_network" "this" {
   address_space = [
     azureipam_reservation.private_dns_resolver.cidr
   ]
-  dns_servers = var.firewall_private_ip_address
+  dns_servers                    = var.firewall_private_ip_address
+  private_endpoint_vnet_policies = "Disabled"
 
   # NOTE: We are using the cidrsubnet() function, and offsetting the bit position by 1, since the parent CIDR is /23 (and we need to split it into two /24s)
   # IMPORTANT: The subnet property changed in azurerm 4.1.0 from `address_prefix` to `address_prefixes`
@@ -66,11 +67,49 @@ resource "azurerm_virtual_network" "this" {
     name             = "inbound_endpoint"
     address_prefixes = [cidrsubnet(azureipam_reservation.private_dns_resolver.cidr, 1, 0)]
     security_group   = azurerm_network_security_group.inbound_endpoint.id
+
+    default_outbound_access_enabled = false
+
+    delegation = [
+      {
+        name = "Microsoft.Network.dnsResolvers"
+        service_delegation = [
+          {
+            name = "Microsoft.Network/dnsResolvers"
+            actions = [
+              "Microsoft.Network/virtualNetworks/subnets/join/action"
+            ]
+          }
+        ]
+      }
+    ]
+
+    private_endpoint_network_policies             = "Disabled"
+    private_link_service_network_policies_enabled = true
   }
 
   subnet {
     name             = "outbound_endpoint"
     address_prefixes = [cidrsubnet(azureipam_reservation.private_dns_resolver.cidr, 1, 1)]
     security_group   = azurerm_network_security_group.outbound_endpoint.id
+
+    default_outbound_access_enabled = false
+
+    delegation = [
+      {
+        name = "Microsoft.Network.dnsResolvers"
+        service_delegation = [
+          {
+            name = "Microsoft.Network/dnsResolvers"
+            actions = [
+              "Microsoft.Network/virtualNetworks/subnets/join/action"
+            ]
+          }
+        ]
+      }
+    ]
+
+    private_endpoint_network_policies             = "Disabled"
+    private_link_service_network_policies_enabled = true
   }
 }

--- a/azure_private_dns/virtual_network/vnet.tf
+++ b/azure_private_dns/virtual_network/vnet.tf
@@ -62,14 +62,14 @@ resource "azurerm_virtual_network" "this" {
 
   # NOTE: We are using the cidrsubnet() function, and offsetting the bit position by 1, since the parent CIDR is /23 (and we need to split it into two /24s)
   subnet {
-    name           = "inbound_endpoint"
-    address_prefix = cidrsubnet(azureipam_reservation.private_dns_resolver.cidr, 1, 0)
-    security_group = azurerm_network_security_group.inbound_endpoint.id
+    name             = "inbound_endpoint"
+    address_prefixes = [cidrsubnet(azureipam_reservation.private_dns_resolver.cidr, 1, 0)]
+    security_group   = azurerm_network_security_group.inbound_endpoint.id
   }
 
   subnet {
-    name           = "outbound_endpoint"
-    address_prefix = cidrsubnet(azureipam_reservation.private_dns_resolver.cidr, 1, 1)
-    security_group = azurerm_network_security_group.outbound_endpoint.id
+    name             = "outbound_endpoint"
+    address_prefixes = [cidrsubnet(azureipam_reservation.private_dns_resolver.cidr, 1, 1)]
+    security_group   = azurerm_network_security_group.outbound_endpoint.id
   }
 }


### PR DESCRIPTION
This pull request includes several updates to the Azure Private DNS Resolver and Virtual Network modules. The most important changes include updating the required versions of Terraform and AzureRM, adding lifecycle rules to ignore changes to specific properties, and modifying subnet configurations to align with the new AzureRM version.

### Version Updates:
* [`azure_private_dns/private_dns_resolver/README.md`](diffhunk://#diff-eff381209cc90694428bf8a9f016b8b680ede8cd909cabad253e35bfa0059502L8-R15): Updated the required versions of `terraform` to `>=1.9.0, < 2.0.0` and `azurerm` to `~> 4.0`.
* [`azure_private_dns/private_dns_resolver/provider.tf`](diffhunk://#diff-bf358bc7d9459e2bc293715bcb843af98c7aed7521d41fda5bf74d4a722eca03L2-R7): Updated the required versions of `terraform` to `>=1.9.0, < 2.0.0` and `azurerm` to `~> 4.0`.
* [`azure_private_dns/virtual_network/README.md`](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3L8-R18): Updated the required versions of `terraform` to `>=1.9.0, < 2.0.0`, `azapi` to `~> 2.0`, `azureipam` to `~> 1.0`, and `azurerm` to `~> 4.0`.

### Lifecycle Rules:
* [`azure_private_dns/private_dns_resolver/private_dns_resolver_dns_forwarding_ruleset.tf`](diffhunk://#diff-4f948a2a41d833c59fbb0215604d0731b08d720db174d5ee74b5a07b14e4f0a9R8-R13): Added lifecycle rule to ignore changes to `tags`.
* [`azure_private_dns/private_dns_resolver/private_dns_resolver_forwarding_rule.tf`](diffhunk://#diff-0af8e51e48d1cf2035731f7c2773599bb0795c42d6e1d7b044cf5071ff99c67dL17-R21): Added lifecycle rule to ignore changes to `metadata`.
* [`azure_private_dns/private_dns_resolver/private_dns_resolver_outbound_endpoint.tf`](diffhunk://#diff-41603edabb70cf1e5fa1afe525b12a740ae2a592ea5eafb41e5a79c63ec1e5b0R7-R12): Added lifecycle rule to ignore changes to `tags`.
* [`azure_private_dns/virtual_network/vhub_connection.tf`](diffhunk://#diff-a483468c52607f611379a285b83dfed812f5dc298717f3c593310ca63502671eR7-R12): Added lifecycle rule to ignore changes to `routing`.

### Subnet Configuration:
* [`azure_private_dns/private_dns_resolver/locals.tf`](diffhunk://#diff-b514d5041c1d56fdc3149b6f1310207d2974ce581347525f8bb14f0a1ad95a35L5-R6): Updated the calculation of `first_available_ip` to use the first element of `address_prefixes`.
* [`azure_private_dns/virtual_network/vnet.tf`](diffhunk://#diff-f71a634f7873b7ef7914d24bba543ef9fc99a5002aa96dd5ea1cdc08a5128db0R62-R113): Modified subnet configurations to use `address_prefixes` instead of `address_prefix` and added additional properties for delegation and network policies.

### Provider Configuration:
* [`azure_private_dns/virtual_network/provider.tf`](diffhunk://#diff-81b781a30ebf443da9774b5f9ccff2aadeb4b0443fad1012e0e72dd6b02a09fcL2-R17): Updated provider configurations and added `enable_preflight` to the `azapi` provider. [[1]](diffhunk://#diff-81b781a30ebf443da9774b5f9ccff2aadeb4b0443fad1012e0e72dd6b02a09fcL2-R17) [[2]](diffhunk://#diff-81b781a30ebf443da9774b5f9ccff2aadeb4b0443fad1012e0e72dd6b02a09fcR31)

### Documentation:
* [`azure_private_dns/virtual_network/README.md`](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3L28-R28): Updated module and input descriptions for consistency and clarity. [[1]](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3L28-R28) [[2]](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3L42-R42)
* [`azure_private_dns/virtual_network/variables.tf`](diffhunk://#diff-0a59d9852acf70890d7542d115f4586bd676a4a84d6f4ccd33b7002c1c4b28afL10-R10): Updated the description of the `environment` variable to indicate it is required.