### PR TITLE
Added contact_emails to budget notifications

### DIFF
--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -88,7 +88,8 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
     operator       = "GreaterThanOrEqualTo"
     threshold_type = "Actual"
 
-    contact_roles = ["Owner"]
+    contact_roles  = ["Owner"]
+    contact_emails = concat([each.value.tags["admin_contact_email"]], split(",", try(each.value.tags["additional_contacts"], "")))
   }
 
   notification {
@@ -97,7 +98,8 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
     operator       = "GreaterThan"
     threshold_type = "Forecasted"
 
-    contact_roles = ["Owner"]
+    contact_roles  = ["Owner"]
+    contact_emails = concat([each.value.tags["admin_contact_email"]], split(",", try(each.value.tags["additional_contacts"], "")))
   }
 
   lifecycle {

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -88,7 +88,6 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
     operator       = "GreaterThanOrEqualTo"
     threshold_type = "Actual"
 
-    contact_roles  = ["Owner"]
     contact_emails = concat([each.value.tags["admin_contact_email"]], split(",", try(each.value.tags["additional_contacts"], "")))
   }
 
@@ -98,7 +97,6 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
     operator       = "GreaterThan"
     threshold_type = "Forecasted"
 
-    contact_roles  = ["Owner"]
     contact_emails = concat([each.value.tags["admin_contact_email"]], split(",", try(each.value.tags["additional_contacts"], "")))
   }
 


### PR DESCRIPTION
The existing method of sending budget alerts to `contact_roles` such as `Owner` is not working and emails are not sent. In order to ensure that teams receive budget alert emails this change uses `contact_emails` instead.