### PR TITLE
Fix dependency resolution: Updated subscription management group ID to reference the Azure management group directly in main.tf

### DIFF
--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -43,7 +43,7 @@ module "lz_vending" {
 
   # management group association variables
   subscription_management_group_association_enabled = true
-  subscription_management_group_id                  = azurerm_management_group.project_set.id
+  subscription_management_group_id                  = replace(azurerm_management_group.project_set.id, "/providers/Microsoft.Management/managementGroups/", "")
 
   # virtual network variables
   virtual_network_enabled = each.value.network.enabled

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -43,7 +43,7 @@ module "lz_vending" {
 
   # management group association variables
   subscription_management_group_association_enabled = true
-  subscription_management_group_id                  = replace(azurerm_management_group.project_set.id, "/providers/Microsoft.Management/managementGroups/", "")
+  subscription_management_group_id                  = trimprefix(azurerm_management_group.project_set.id, "/providers/Microsoft.Management/managementGroups/")
 
   # virtual network variables
   virtual_network_enabled = each.value.network.enabled

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -43,7 +43,7 @@ module "lz_vending" {
 
   # management group association variables
   subscription_management_group_association_enabled = true
-  subscription_management_group_id                  = var.license_plate
+  subscription_management_group_id                  = azurerm_management_group.project_set.id
 
   # virtual network variables
   virtual_network_enabled = each.value.network.enabled

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -63,6 +63,8 @@ module "lz_vending" {
       tags        = var.common_tags
     }
   } : {}
+
+  depends_on = [azurerm_management_group.project_set]
 }
 
 # Create budgets directly using azurerm provider instead of the lz-vending module


### PR DESCRIPTION
The lz vending module did not properly depend on the management group which was causing it to be destroyed before the subscriptions.

The subscriptions were then moved to the root which we do not have access to.