### PR TITLE
Fixed broken ref link

### DIFF
--- a/caf_cccs_medium/custom.private.dns.zones.tf
+++ b/caf_cccs_medium/custom.private.dns.zones.tf
@@ -6,7 +6,7 @@
 # This custom Private DNS Zone inclusion has the same challenge, where it needs the Private DNS Resolver VNet ID to link the Private DNS Zones.
 
 module "lz_custom_private_dns_zones" {
-  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_private_dns/private_dns_zone?ref=v0.0.18"
+  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_private_dns/private_dns_zone?ref=v1.0.18"
   # source = "../azure_private_dns/private_dns_zone" # NOTE: For local testing only, replace with the above for production
 
   providers = {
@@ -19,7 +19,7 @@ module "lz_custom_private_dns_zones" {
 }
 
 module "private_dns_zone_virtual_network_link" {
-  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_private_dns/private_dns_zone_virtual_network_link?ref=v0.0.18"
+  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_private_dns/private_dns_zone_virtual_network_link?ref=v1.0.18"
   # source = "../azure_private_dns/private_dns_zone_virtual_network_link" # NOTE: For local testing only, replace with the above for production
 
   providers = {


### PR DESCRIPTION
This pull request updates the source references for two Terraform modules in the `caf_cccs_medium/custom.private.dns.zones.tf` file to use a newer version. These changes ensure that the infrastructure uses the latest features and fixes from the upstream repository.

Module version updates:

* Updated the `lz_custom_private_dns_zones` module source to use version `v1.0.18` of the `azure_private_dns/private_dns_zone` module.
* Updated the `private_dns_zone_virtual_network_link` module source to use version `v1.0.18` of the `azure_private_dns/private_dns_zone_virtual_network_link` module.