### PR TITLE
Re-Added Firewall Insights

### DIFF
--- a/caf_cccs_medium/firewall.lz.policy.tf
+++ b/caf_cccs_medium/firewall.lz.policy.tf
@@ -18,6 +18,12 @@ module "lz_firewall_policy" {
   dns               = var.dns ## TODO: Update to use module output
   private_ip_ranges = var.private_ip_ranges != null ? var.private_ip_ranges : []
 
+  insights = {
+    enabled                            = true
+    default_log_analytics_workspace_id = "${values(module.management.log_analytics_workspace)[0].id}"
+    retention_in_days                  = 90
+  }
+
   sku = var.sku
 
   # NOTE: "Threat Intel Mode should be stricter than the Base Policy", therefore using the Base Policy's Threat Intel Mode


### PR DESCRIPTION
This pull request introduces a configuration update to the `lz_firewall_policy` module in `firewall.lz.policy.tf`, specifically enabling and configuring firewall insights for improved monitoring and logging. The main change is the addition of an `insights` block that sets up logging to a Log Analytics workspace with a defined retention period.

**Firewall monitoring and logging enhancements:**

* Added an `insights` block to the `lz_firewall_policy` module, enabling firewall insights, specifying the default Log Analytics workspace (`module.management.log_analytics_workspace`), and setting log retention to 90 days.