### PR TITLE
IP Group module variable validation fix

### DIFF
--- a/azure_ip_group/locals.tf
+++ b/azure_ip_group/locals.tf
@@ -3,15 +3,4 @@ locals {
 
   # IP range validation regex pattern (extracted for readability)
   ip_range_regex = "^((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\-((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)$"
-
-  # Validation logic for IP addresses (moved from variable validation)
-  ip_group_validation = alltrue([
-    for obj in var.ip_group : alltrue([
-      for ip in obj.ip_addresses : (
-        provider::assert::cidrv4(ip) ||
-        provider::assert::ipv4(ip) ||
-        can(regex(local.ip_range_regex, ip))
-      )
-    ])
-  ])
 }

--- a/azure_ip_group/locals.tf
+++ b/azure_ip_group/locals.tf
@@ -1,6 +1,3 @@
 locals {
   subscription_id_connectivity = coalesce(var.subscription_id_connectivity, data.azurerm_client_config.current.subscription_id)
-
-  # IP range validation regex pattern (extracted for readability)
-  ip_range_regex = "^((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\-((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)$"
 }

--- a/azure_ip_group/variables.ip_group.tf
+++ b/azure_ip_group/variables.ip_group.tf
@@ -15,7 +15,15 @@ variable "ip_group" {
   }
 
   validation {
-    condition     = local.ip_group_validation
+    condition = alltrue([
+      for obj in var.ip_group : alltrue([
+        for ip in obj.ip_addresses : (
+          provider::assert::cidrv4(ip) ||
+          provider::assert::ipv4(ip) ||
+          can(regex(local.ip_range_regex, ip))
+        )
+      ])
+    ])
     error_message = <<DESCRIPTION
 Each IP address in every IP Group must be either:
 - A valid IPv4 address (e.g., '192.168.1.1'),

--- a/azure_ip_group/variables.ip_group.tf
+++ b/azure_ip_group/variables.ip_group.tf
@@ -20,7 +20,7 @@ variable "ip_group" {
         for ip in obj.ip_addresses : (
           provider::assert::cidrv4(ip) ||
           provider::assert::ipv4(ip) ||
-          can(regex(local.ip_range_regex, ip))
+          can(regex("^((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\-((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)$", ip))
         )
       ])
     ])

--- a/caf_cccs_medium/README.md
+++ b/caf_cccs_medium/README.md
@@ -41,7 +41,7 @@ Policies are applied in the "Default" mode. It should be possible to provide [ov
 | <a name="module_connectivity"></a> [connectivity](#module\_connectivity) | ./modules/connectivity | n/a |
 | <a name="module_core"></a> [core](#module\_core) | ./modules/core | n/a |
 | <a name="module_lz_custom_private_dns_zones"></a> [lz\_custom\_private\_dns\_zones](#module\_lz\_custom\_private\_dns\_zones) | git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_private_dns/private_dns_zone | v1.0.19 |
-| <a name="module_lz_firewall_ipgroups"></a> [lz\_firewall\_ipgroups](#module\_lz\_firewall\_ipgroups) | git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_ip_group | v1.0.23 |
+| <a name="module_lz_firewall_ipgroups"></a> [lz\_firewall\_ipgroups](#module\_lz\_firewall\_ipgroups) | git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_ip_group | v1.0.24 |
 | <a name="module_lz_firewall_policy"></a> [lz\_firewall\_policy](#module\_lz\_firewall\_policy) | git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_firewall/firewall_policy | v0.0.20 |
 | <a name="module_lz_firewall_policy_rules"></a> [lz\_firewall\_policy\_rules](#module\_lz\_firewall\_policy\_rules) | git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_firewall/firewall_policy_rcg | v0.0.20 |
 | <a name="module_management"></a> [management](#module\_management) | ./modules/management | n/a |

--- a/caf_cccs_medium/firewall.lz.ipgroups.tf
+++ b/caf_cccs_medium/firewall.lz.ipgroups.tf
@@ -1,5 +1,5 @@
 module "lz_firewall_ipgroups" {
-  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_ip_group?ref=v1.0.23"
+  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_ip_group?ref=v1.0.24"
   # source = "../azure_ip_group"
 
   subscription_id_connectivity = var.subscription_id_connectivity


### PR DESCRIPTION
This pull request updates the Azure IP Group module to use version `v1.0.24` and refactors IP address validation logic. The most significant changes are the version bump for the IP group module and the relocation of validation logic to improve maintainability and clarity.

**Module version update:**
* Updated the `lz_firewall_ipgroups` module source to use version `v1.0.24` in both the `firewall.lz.ipgroups.tf` file and the documentation (`README.md`). [[1]](diffhunk://#diff-3f719b886669bd7dbc8e40a1e1e8db1002ce903c9cb88c57a33f79d7f78fe7edL2-R2) [[2]](diffhunk://#diff-df4ba27ee4b54a67ff2c6c40e58b635bdd0a246034831c132f7648420cadfe00L44-R44)

**IP address validation refactor:**
* Moved the IP address validation logic directly into the `ip_group` variable's validation block, removing the redundant local variable and making the validation more transparent and easier to maintain. [[1]](diffhunk://#diff-e85fcf9beec354adf5ae344e70322196f1193a09f08f887e0d43b600164de969L6-L16) [[2]](diffhunk://#diff-17c1e823b5265fc54396549fd3be31177b40c80e39036894a636540e3b0c3decL18-R26)