### PR TITLE
Updated AMBA module versions

### DIFF
--- a/azure_monitor_baseline_alerts/README.md
+++ b/azure_monitor_baseline_alerts/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9, < 2.0 |
-| <a name="requirement_alz"></a> [alz](#requirement\_alz) | ~> 0.17 |
+| <a name="requirement_alz"></a> [alz](#requirement\_alz) | ~> 0.20 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 
@@ -21,7 +21,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_amba_alz"></a> [amba\_alz](#module\_amba\_alz) | Azure/avm-ptn-monitoring-amba-alz/azurerm | 0.3.0 |
-| <a name="module_amba_policy"></a> [amba\_policy](#module\_amba\_policy) | Azure/avm-ptn-alz/azurerm | 0.15.0 |
+| <a name="module_amba_policy"></a> [amba\_policy](#module\_amba\_policy) | Azure/avm-ptn-alz/azurerm | 0.19.0 |
 
 ## Resources
 

--- a/azure_monitor_baseline_alerts/main.tf
+++ b/azure_monitor_baseline_alerts/main.tf
@@ -15,7 +15,7 @@ module "amba_alz" {
 
 module "amba_policy" {
   source             = "Azure/avm-ptn-alz/azurerm"
-  version            = "0.15.0"
+  version            = "0.19.0"
   architecture_name  = var.architecture_name
   location           = var.location
   parent_resource_id = var.parent_resource_id

--- a/azure_monitor_baseline_alerts/provider.tf
+++ b/azure_monitor_baseline_alerts/provider.tf
@@ -14,7 +14,7 @@ terraform {
 
     alz = {
       source  = "azure/alz"
-      version = "~> 0.17"
+      version = "~> 0.20"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the version requirements for key Terraform modules and providers in the `azure_monitor_baseline_alerts` module to ensure compatibility with newer releases and improvements. The most important changes are:

**Module and Provider Version Updates:**

* Updated the `alz` provider version requirement from `~> 0.17` to `~> 0.20` in both `provider.tf` and the documentation to support newer features and bug fixes. [[1]](diffhunk://#diff-c6e0c0c3f372da708f8e875b72fe851cc10d12fd67b0726d5c61c6a7123cf68bL17-R17) [[2]](diffhunk://#diff-14493f6833e23ad0bd6e1eb19429ae6cc943a566a5f3e708b73d3ba8bec92817L9-R9)
* Updated the `amba_policy` module version from `0.15.0` to `0.19.0` in both `main.tf` and the documentation for improved compatibility and enhancements. [[1]](diffhunk://#diff-6bccc4906d07bf8892c1dabcf5fee1bb660279fcfb6b01fdcadb52699a9d68acL18-R18) [[2]](diffhunk://#diff-14493f6833e23ad0bd6e1eb19429ae6cc943a566a5f3e708b73d3ba8bec92817L24-R24)