### PR TITLE
UDR Protection Policies

### DIFF
--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
@@ -8,6 +8,7 @@
       "FedRAMPModerate",
       "Deny-VNet-DNS-Changes",
       "Deny-Protected-Network",
+      "Deny-Delete-Protected-Routes",
       "Deny-VNet-Creation",
       "Deny-New-VNet-Peerings",
       "Deny-Delete-Diagnostics",

--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
@@ -8,7 +8,7 @@
       "FedRAMPModerate",
       "Deny-VNet-DNS-Changes",
       "Deny-Protected-Network",
-      "Deny-Delete-Protected-Routes",
+      "Deny-Delete-Routes",
       "Deny-VNet-Creation",
       "Deny-New-VNet-Peerings",
       "Deny-Delete-Diagnostics",
@@ -45,6 +45,10 @@
         },
         "InheritTag-Ministry-Name": {
           "value": "ministry_name"
+        },
+        "Deny-Protected-Network": {
+          "protectedRouteTableId": "SET using local.archetype_config_overrides",
+          "protectedSubnetId": "SET using local.archetype_config_overrides"
         },
         "Deny-VNet-DNS-Changes": {
           "VNet-DNS-Settings": "SET using local.archetype_config_overrides"

--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
@@ -23,6 +23,7 @@
       "Deploy-Private-DNS-Redis",
       "Deny-VNet-DNS-Changes",
       "Deny-Protected-Network-Resources",
+      "Deny-Deleting-Protected-Route-Resources",
       "Deny-Delete-NetworkWatcher",
       "Deny-VNet-Creation",
       "Deny-New-VNet-Peerings",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_creating_protected_network_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_creating_protected_network_resources.json
@@ -3,12 +3,18 @@
   "type": "Microsoft.Authorization/policyAssignments",
   "apiVersion": "2019-09-01",
   "properties": {
-    "displayName": "Deny Creating Protected Networking Resource",
-    "description": "This Policy will prevent users from creating Express Route circuits, VPN Sites, VPN/NAT/Local Gateways, Route Tables or Network Security Perimeters.",
+    "displayName": "Deny Creating and Modifying Protected Networking Resources",
+    "description": "This Policy will prevent users from creating Express Route circuits, VPN Sites, VPN/NAT/Local Gateways, Route Tables or Network Security Perimeters. It also prevents route child-resource operations (e.g. edit/delete).",
     "notScopes": [],
     "parameters": {
       "effect": {
         "value": "Deny"
+      },
+      "protectedRouteTableId": {
+        "value": ""
+      },
+      "protectedSubnetId": {
+        "value": ""
       }
     },
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Protected-Network-Resources",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_deleting_protected_route_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_deleting_protected_route_resources.json
@@ -1,10 +1,10 @@
 {
-  "name": "Deny-Delete-Protected-Routes",
+  "name": "Deny-Delete-Routes",
   "type": "Microsoft.Authorization/policyAssignments",
   "apiVersion": "2019-09-01",
   "properties": {
     "displayName": "Deny Deleting Protected Route Resources",
-    "description": "This policy prevents users from deleting protected route tables and route entries.",
+    "description": "This Policy prevents deletion of route tables and route table routes in the Landing Zones.",
     "notScopes": [],
     "parameters": {
       "effect": {
@@ -14,7 +14,7 @@
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Deleting-Protected-Route-Resources",
     "nonComplianceMessages": [
       {
-        "message": "Deleting protected route tables or route entries in Landing Zones is not allowed."
+        "message": "Deletion of route tables and routes in the Landing Zones is not allowed."
       }
     ],
     "scope": "${current_scope_resource_id}",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_deleting_protected_route_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_deleting_protected_route_resources.json
@@ -1,0 +1,27 @@
+{
+  "name": "Deny-Delete-Protected-Routes",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2019-09-01",
+  "properties": {
+    "displayName": "Deny Deleting Protected Route Resources",
+    "description": "This policy prevents users from deleting protected route tables and route entries.",
+    "notScopes": [],
+    "parameters": {
+      "effect": {
+        "value": "denyAction"
+      }
+    },
+    "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Deleting-Protected-Route-Resources",
+    "nonComplianceMessages": [
+      {
+        "message": "Deleting protected route tables or route entries in Landing Zones is not allowed."
+      }
+    ],
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
@@ -9,9 +9,9 @@
     "policyType": "Custom",
     "mode": "All",
     "metadata": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "category": "Networking",
-      "updatedDate": "2026-04-06"
+      "updatedDate": "2026-04-07"
     },
     "parameters": {
       "effect": {
@@ -81,10 +81,6 @@
           },
           {
             "field": "type",
-            "equals": "Microsoft.Network/routeTables/routes"
-          },
-          {
-            "field": "type",
             "like": "Microsoft.Network/routeTables/*"
           },
           {
@@ -98,22 +94,6 @@
           {
             "field": "type",
             "equals": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules"
-          },
-          {
-            "allOf": [
-              {
-                "value": "[parameters('protectedRouteTableId')]",
-                "notEquals": ""
-              },
-              {
-                "field": "type",
-                "equals": "Microsoft.Network/routeTables/routes"
-              },
-              {
-                "field": "id",
-                "like": "[concat(parameters('protectedRouteTableId'), '/routes/*')]"
-              }
-            ]
           },
           {
             "allOf": [

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
@@ -4,13 +4,14 @@
   "apiVersion": "2024-05-01",
   "scope": null,
   "properties": {
-    "displayName": "Deny Creating Protected Networking Resource",
-    "description": "This Policy will prevent users from creating Express Route circuits, VPN Sites, VPN/NAT/Local Gateways, Route Tables or Network Security Perimeteres.",
+    "displayName": "Deny Creating and Modifying Protected Networking Resources",
+    "description": "This Policy prevents users from creating/modifying protected network resources. It also blocks route child-resource operations and can enforce a protected route table to remain associated only to one protected subnet.",
     "policyType": "Custom",
     "mode": "All",
     "metadata": {
-      "version": "1.0.0",
-      "category": "Networking"
+      "version": "1.0.2",
+      "category": "Networking",
+      "updatedDate": "2026-04-02"
     },
     "parameters": {
       "effect": {
@@ -25,6 +26,22 @@
           "Disabled"
         ],
         "defaultValue": "Deny"
+      },
+      "protectedRouteTableId": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Protected Route Table Resource ID",
+          "description": "Optional. When set with protectedSubnetId, the policy enforces that this route table stays associated only to the protected subnet and blocks reassociation/disassociation attempts."
+        },
+        "defaultValue": ""
+      },
+      "protectedSubnetId": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Protected Subnet Resource ID",
+          "description": "Optional. When set with protectedRouteTableId, this subnet must remain associated to the protected route table."
+        },
+        "defaultValue": ""
       }
     },
     "policyRule": {
@@ -64,6 +81,10 @@
           },
           {
             "field": "type",
+            "equals": "Microsoft.Network/routeTables/routes"
+          },
+          {
+            "field": "type",
             "equals": "Microsoft.Network/networkSecurityPerimeters"
           },
           {
@@ -73,6 +94,66 @@
           {
             "field": "type",
             "equals": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules"
+          },
+          {
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Network/virtualNetworks/subnets"
+              },
+              {
+                "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
+                "exists": true
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "value": "[parameters('protectedRouteTableId')]",
+                "notEquals": ""
+              },
+              {
+                "value": "[parameters('protectedSubnetId')]",
+                "notEquals": ""
+              },
+              {
+                "field": "type",
+                "equals": "Microsoft.Network/virtualNetworks/subnets"
+              },
+              {
+                "field": "id",
+                "equals": "[parameters('protectedSubnetId')]"
+              },
+              {
+                "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
+                "notEquals": "[parameters('protectedRouteTableId')]"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "value": "[parameters('protectedRouteTableId')]",
+                "notEquals": ""
+              },
+              {
+                "value": "[parameters('protectedSubnetId')]",
+                "notEquals": ""
+              },
+              {
+                "field": "type",
+                "equals": "Microsoft.Network/virtualNetworks/subnets"
+              },
+              {
+                "field": "id",
+                "notEquals": "[parameters('protectedSubnetId')]"
+              },
+              {
+                "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
+                "equals": "[parameters('protectedRouteTableId')]"
+              }
+            ]
           }
         ]
       },

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
@@ -5,13 +5,13 @@
   "scope": null,
   "properties": {
     "displayName": "Deny Creating and Modifying Protected Networking Resources",
-    "description": "This Policy prevents users from creating/modifying protected network resources. It also blocks route child-resource operations and can enforce a protected route table to remain associated only to one protected subnet.",
+    "description": "This policy prevents users from creating or modifying protected networking resources (ExpressRoute circuits, VPN sites/gateways, NAT/local gateways, route tables, and Network Security Perimeters). It also blocks route child-resource operations (including delete) and protected subnet-to-UDR disassociation.",
     "policyType": "Custom",
     "mode": "All",
     "metadata": {
-      "version": "1.0.2",
+      "version": "1.0.4",
       "category": "Networking",
-      "updatedDate": "2026-04-02"
+      "updatedDate": "2026-04-06"
     },
     "parameters": {
       "effect": {
@@ -85,6 +85,10 @@
           },
           {
             "field": "type",
+            "like": "Microsoft.Network/routeTables/*"
+          },
+          {
+            "field": "type",
             "equals": "Microsoft.Network/networkSecurityPerimeters"
           },
           {
@@ -110,6 +114,28 @@
           {
             "allOf": [
               {
+                "field": "type",
+                "equals": "Microsoft.Network/virtualNetworks/subnets"
+              },
+              {
+                "field": "name",
+                "notIn": [
+                  "GatewaySubnet",
+                  "AzureBastionSubnet",
+                  "AzureFirewallSubnet",
+                  "AzureFirewallManagementSubnet",
+                  "RouteServerSubnet"
+                ]
+              },
+              {
+                "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
+                "exists": false
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
                 "value": "[parameters('protectedRouteTableId')]",
                 "notEquals": ""
               },
@@ -126,8 +152,32 @@
                 "equals": "[parameters('protectedSubnetId')]"
               },
               {
-                "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
-                "notEquals": "[parameters('protectedRouteTableId')]"
+                "anyOf": [
+                  {
+                    "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
+                    "exists": false
+                  },
+                  {
+                    "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
+                    "notEquals": "[parameters('protectedRouteTableId')]"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "value": "[parameters('protectedRouteTableId')]",
+                "notEquals": ""
+              },
+              {
+                "field": "type",
+                "equals": "Microsoft.Network/routeTables/routes"
+              },
+              {
+                "field": "id",
+                "like": "[concat(parameters('protectedRouteTableId'), '/routes/*')]"
               }
             ]
           },

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_creating_protected_network_resources.json
@@ -5,11 +5,11 @@
   "scope": null,
   "properties": {
     "displayName": "Deny Creating and Modifying Protected Networking Resources",
-    "description": "This policy prevents users from creating or modifying protected networking resources (ExpressRoute circuits, VPN sites/gateways, NAT/local gateways, route tables, and Network Security Perimeters). It also blocks route child-resource operations (including delete) and protected subnet-to-UDR disassociation.",
+    "description": "This policy prevents users from creating or modifying protected networking resources (ExpressRoute circuits, VPN sites/gateways, NAT/local gateways, route tables, and Network Security Perimeters). It blocks route child-resource operations and optionally prevents a designated protected route table from being associated to other subnets.",
     "policyType": "Custom",
     "mode": "All",
     "metadata": {
-      "version": "1.0.4",
+      "version": "1.0.7",
       "category": "Networking",
       "updatedDate": "2026-04-06"
     },
@@ -31,7 +31,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Protected Route Table Resource ID",
-          "description": "Optional. When set with protectedSubnetId, the policy enforces that this route table stays associated only to the protected subnet and blocks reassociation/disassociation attempts."
+          "description": "Optional. When set with protectedSubnetId, the policy prevents this route table from being associated to subnets other than the protected subnet."
         },
         "defaultValue": ""
       },
@@ -39,7 +39,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Protected Subnet Resource ID",
-          "description": "Optional. When set with protectedRouteTableId, this subnet must remain associated to the protected route table."
+          "description": "Optional. Identifies the protected subnet for association control when set with protectedRouteTableId."
         },
         "defaultValue": ""
       }
@@ -98,72 +98,6 @@
           {
             "field": "type",
             "equals": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules"
-          },
-          {
-            "allOf": [
-              {
-                "field": "type",
-                "equals": "Microsoft.Network/virtualNetworks/subnets"
-              },
-              {
-                "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
-                "exists": true
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "field": "type",
-                "equals": "Microsoft.Network/virtualNetworks/subnets"
-              },
-              {
-                "field": "name",
-                "notIn": [
-                  "GatewaySubnet",
-                  "AzureBastionSubnet",
-                  "AzureFirewallSubnet",
-                  "AzureFirewallManagementSubnet",
-                  "RouteServerSubnet"
-                ]
-              },
-              {
-                "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
-                "exists": false
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "value": "[parameters('protectedRouteTableId')]",
-                "notEquals": ""
-              },
-              {
-                "value": "[parameters('protectedSubnetId')]",
-                "notEquals": ""
-              },
-              {
-                "field": "type",
-                "equals": "Microsoft.Network/virtualNetworks/subnets"
-              },
-              {
-                "field": "id",
-                "equals": "[parameters('protectedSubnetId')]"
-              },
-              {
-                "anyOf": [
-                  {
-                    "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
-                    "exists": false
-                  },
-                  {
-                    "field": "Microsoft.Network/virtualNetworks/subnets/routeTable.id",
-                    "notEquals": "[parameters('protectedRouteTableId')]"
-                  }
-                ]
-              }
-            ]
           },
           {
             "allOf": [

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_deleting_protected_route_resources.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deny_deleting_protected_route_resources.json
@@ -1,0 +1,53 @@
+{
+  "name": "Deny-Deleting-Protected-Route-Resources",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "apiVersion": "2024-05-01",
+  "scope": null,
+  "properties": {
+    "displayName": "Deny Deleting Protected Route Resources",
+    "description": "This policy prevents deletion of route tables and route table routes. Use this with a deny policy that blocks create/update operations.",
+    "policyType": "Custom",
+    "mode": "All",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Networking",
+      "updatedDate": "2026-04-02"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "denyAction or Disabled"
+        },
+        "allowedValues": [
+          "denyAction",
+          "Disabled"
+        ],
+        "defaultValue": "denyAction"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "anyOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/routeTables"
+          },
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/routeTables/routes"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "actionNames": [
+            "delete"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -63,6 +63,10 @@ locals {
         Deploy-VMSS-Monitoring = {
           scopeToSupportedImages = true
         },
+        Deny-Protected-Network = {
+          protectedRouteTableId = ""
+          protectedSubnetId     = ""
+        },
         Deny-VNet-DNS-Changes = {
           VNet-DNS-Settings = var.VNet-DNS-Settings
         },


### PR DESCRIPTION
This pull request introduces new and updated Azure policy definitions and assignments to strengthen protection over networking resources, especially focusing on preventing unauthorized creation, modification, and deletion of protected route tables and their routes. The changes enhance existing policies, add new granular controls, and update archetype extensions to reference these controls.

**Policy definition and assignment enhancements:**

* Added a new policy definition, `policy_definition_deny_deleting_protected_route_resources.json`, which specifically denies deletion of route tables and route table routes, and a corresponding policy assignment, `policy_assignment_deny_deleting_protected_route_resources.json`. [[1]](diffhunk://#diff-9f9550d426c486880f2e027c6a52ab93b69811d2f77ba40dde601ee8f310044aR1-R53) [[2]](diffhunk://#diff-a5c1758fd1cda4ba17239599ada4422ee025eeba180afe5c95781041c3d5c13cR1-R27)
* Enhanced the `policy_definition_deny_creating_protected_network_resources.json` to also block modification (not just creation) of protected networking resources, including new logic to enforce subnet-to-UDR associations and prevent child-resource operations such as edit/delete on routes. Added parameters for `protectedRouteTableId` and `protectedSubnetId` for more granular control. [[1]](diffhunk://#diff-1754f70f0207fee15bf9cb2c669254628bfe1d49fb31164a083b7c78a9195ce5L7-R14) [[2]](diffhunk://#diff-1754f70f0207fee15bf9cb2c669254628bfe1d49fb31164a083b7c78a9195ce5R29-R44) [[3]](diffhunk://#diff-1754f70f0207fee15bf9cb2c669254628bfe1d49fb31164a083b7c78a9195ce5R82-R89) [[4]](diffhunk://#diff-1754f70f0207fee15bf9cb2c669254628bfe1d49fb31164a083b7c78a9195ce5R101-R206)
* Updated the corresponding policy assignment, `policy_assignment_deny_creating_protected_network_resources.json`, to reflect the new parameters and expanded description.

**Archetype extension updates:**

* Updated `archetype_extension_es_landing_zones.tmpl.json` to reference the new "Deny-Delete-Routes" policy and to pass the required parameters for "Deny-Protected-Network". [[1]](diffhunk://#diff-1793ace63156162ac6f68e852ccaefbe296954a103535746a486a9fc4a19fde7R11) [[2]](diffhunk://#diff-1793ace63156162ac6f68e852ccaefbe296954a103535746a486a9fc4a19fde7R49-R52)
* Updated `archetype_extension_es_root.tmpl.json` to reference the new "Deny-Deleting-Protected-Route-Resources" policy.