### PR TITLE
AKS Security and Compliance Policies

### DIFF
--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_landing_zones.tmpl.json
@@ -9,6 +9,7 @@
       "Deny-VNet-DNS-Changes",
       "Deny-Protected-Network",
       "Deny-VNet-Creation",
+      "Enforce-AKS-CIDRs",
       "Deny-New-VNet-Peerings",
       "Deny-Delete-Diagnostics",
       "Deny-AMPLS-Creation",
@@ -47,6 +48,12 @@
         },
         "Deny-VNet-DNS-Changes": {
           "VNet-DNS-Settings": "SET using local.archetype_config_overrides"
+        },
+        "Enforce-AKS-CIDRs": {
+          "allowedPodCidrRanges": "SET using local.archetype_config_overrides",
+          "enforceServiceCidr": "SET using local.archetype_config_overrides",
+          "allowedServiceCidrRanges": "SET using local.archetype_config_overrides",
+          "effect": "SET using local.archetype_config_overrides"
         },
         "Deny-Delete-NetworkWatch": {
           "Network-Watcher-storageId": "SET using local.archetype_config_overrides",

--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
@@ -29,6 +29,7 @@
       "Deny-Delete-Diagnostics",
       "Resource-Locations",
       "Deny-AMPLS-Creation",
+      "Enforce-AKS-CIDRs",
       "Deploy-NSP-Resource-Association"
     ],
     "policy_set_definitions": [

--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
@@ -12,7 +12,9 @@
       "Deny-AppGw-Without-Tls",
       "Deploy-Private-DNS-PSQL",
       "MicrosoftCISv2",
-      "NIST-SP-800-53-Rev5"
+      "NIST-SP-800-53-Rev5",
+      "AKS-CIS-Benchmark",
+      "AKS-Best-Practices"
     ],
     "policy_definitions": [
       "Inherit-Account-Code-Tag",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_aks_best_practices.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_aks_best_practices.json
@@ -8,7 +8,27 @@
     "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/c047ea8e-9c78-49b2-958b-37e56d291a44",
     "metadata": {},
     "notScopes": [],
-    "parameters": {},
+    "parameters": {
+      "allowedUsers": {
+        "value": []
+      },
+      "allowedGroups": {
+        "value": []
+      },
+      "allowedContainerImagesRegex": {
+        "value": "^([^\\/]+\\.azurecr\\.io|registry\\.io)\\/.+$"
+      },
+      "labels": {
+        "value": [
+          "kubernetes.azure.com"
+        ]
+      },
+      "reservedTaints": {
+        "value": [
+          "CriticalAddonsOnly"
+        ]
+      }
+    },
     "nonComplianceMessages": [],
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_aks_best_practices.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_aks_best_practices.json
@@ -1,0 +1,21 @@
+{
+  "name": "AKS-Best-Practices",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2024-04-01",
+  "properties": {
+    "displayName": "Deployment safeguards should help guide developers towards AKS recommended best practices",
+    "description": "A collection of Kubernetes best practices that are recommended by Azure Kubernetes Service (AKS). For the best experience, use deployment safeguards to assign this policy initiative: https://aka.ms/aks/deployment-safeguards. Azure Policy Add-On for AKS is a pre-requisite for applying these best practices to your clusters. For instructions on enabling the Azure Policy Add-On, go to aka.ms/akspolicydoc",
+    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/c047ea8e-9c78-49b2-958b-37e56d291a44",
+    "metadata": {},
+    "notScopes": [],
+    "parameters": {},
+    "nonComplianceMessages": [],
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default",
+    "overrides": []
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_aks_cis_benchmark.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_aks_cis_benchmark.json
@@ -1,0 +1,21 @@
+{
+  "name": "AKS-CIS-Benchmark",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2024-04-01",
+  "properties": {
+    "displayName": "Security control recommendations of Center for Internet Security (CIS) Kubernetes benchmark",
+    "description": "This initiative includes the policies for the security recommendation for Center for Internet Security (CIS) Kubernetes benchmark, you can use this initiative to stay compliant with CIS Kubernetes benchmark. For more information of CIS compliance, visit: https://aka.ms/aks/cis-kubernetes",
+    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/4fd005fd-51be-478f-a8fb-149d48b20d48",
+    "metadata": {},
+    "notScopes": [],
+    "parameters": {},
+    "nonComplianceMessages": [],
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default",
+    "overrides": []
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
@@ -1,0 +1,40 @@
+{
+  "name": "Enforce-AKS-CIDRs",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2019-09-01",
+  "properties": {
+    "displayName": "Enforce AKS Pod and Service CIDR ranges",
+    "description": "Restricts AKS Pod CIDR to an approved range and optionally enforces a Service CIDR range.",
+    "notScopes": [],
+    "parameters": {
+      "allowedPodCidrRanges": {
+        "value": [
+          "10.10.0.0/16"
+        ]
+      },
+      "enforceServiceCidr": {
+        "value": false
+      },
+      "allowedServiceCidrRanges": {
+        "value": [
+          "10.20.0.0/16"
+        ]
+      },
+      "effect": {
+        "value": "Deny"
+      }
+    },
+    "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Enforce-AKS-CIDRs",
+    "nonComplianceMessages": [
+      {
+        "message": "AKS podCidr must be contained within the approved range. Service CIDR is also validated when enabled."
+      }
+    ],
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
@@ -29,7 +29,7 @@
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Enforce-AKS-CIDRs",
     "nonComplianceMessages": [
       {
-        "message": "AKS Pod CIDR and Service CIDR must be contained within the approved range. Please refer to [TechDocs](https://developer.gov.bc.ca/docs/default/component/public-cloud-techdocs/) for more information."
+        "message": "AKS Pod CIDR and Service CIDR must be contained within the approved range. For more information, see https://developer.gov.bc.ca/docs/default/component/public-cloud-techdocs/."
       }
     ],
     "scope": "${current_scope_resource_id}",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
@@ -9,15 +9,17 @@
     "parameters": {
       "allowedPodCidrRanges": {
         "value": [
-          "10.10.0.0/16"
+          "10.10.0.0/18",
+          "10.10.128.0/18"
         ]
       },
       "enforceServiceCidr": {
-        "value": false
+        "value": true
       },
       "allowedServiceCidrRanges": {
         "value": [
-          "10.20.0.0/16"
+          "10.10.64.0/22",
+          "10.10.192.0/22"
         ]
       },
       "effect": {

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
@@ -27,7 +27,7 @@
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Enforce-AKS-CIDRs",
     "nonComplianceMessages": [
       {
-        "message": "AKS podCidr must be contained within the approved range. Service CIDR is also validated when enabled."
+        "message": "AKS Pod CIDR and Service CIDR must be contained within the approved range. Please refer to [TechDocs](https://developer.gov.bc.ca/docs/default/component/public-cloud-techdocs/) for more information."
       }
     ],
     "scope": "${current_scope_resource_id}",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_guardrails.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_guardrails.json
@@ -1,0 +1,21 @@
+{
+  "name": "Enforce-Guardrails-AKS",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2024-04-01",
+  "properties": {
+    "displayName": "Enforce recommended guardrails for Kubernetes",
+    "description": "This policy initiative is a group of policies that ensures Kubernetes is compliant per regulated Landing Zones.",
+    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/Enforce-Guardrails-Kubernetes",
+    "metadata": {},
+    "notScopes": [],
+    "parameters": {},
+    "nonComplianceMessages": [],
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default",
+    "overrides": []
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_enforce_aks_cidrs.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_enforce_aks_cidrs.json
@@ -1,0 +1,106 @@
+{
+  "name": "Enforce-AKS-CIDRs",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "apiVersion": "2024-05-01",
+  "scope": null,
+  "properties": {
+    "displayName": "Enforce AKS Pod and Service CIDR ranges",
+    "description": "Restricts AKS Pod CIDR to an approved range and optionally enforces a Service CIDR range.",
+    "policyType": "Custom",
+    "mode": "All",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Kubernetes"
+    },
+    "parameters": {
+      "allowedPodCidrRanges": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed Pod CIDR Ranges",
+          "description": "AKS podCidr must be fully contained in one of these CIDR ranges."
+        },
+        "defaultValue": [
+          "10.10.0.0/16"
+        ]
+      },
+      "enforceServiceCidr": {
+        "type": "Boolean",
+        "metadata": {
+          "displayName": "Enforce Service CIDR",
+          "description": "When true, AKS serviceCidr must be fully contained in the allowed Service CIDR range."
+        },
+        "defaultValue": false
+      },
+      "allowedServiceCidrRanges": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed Service CIDR Ranges",
+          "description": "AKS serviceCidr must be fully contained in one of these CIDR ranges when Service CIDR enforcement is enabled."
+        },
+        "defaultValue": [
+          "10.20.0.0/16"
+        ]
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.ContainerService/managedClusters"
+          },
+          {
+            "anyOf": [
+              {
+                "count": {
+                  "value": "[parameters('allowedPodCidrRanges')]",
+                  "name": "allowedPodCidrRange",
+                  "where": {
+                    "value": "[if(empty(field('Microsoft.ContainerService/managedClusters/networkProfile.podCidr')), bool('false'), ipRangeContains(current('allowedPodCidrRange'), field('Microsoft.ContainerService/managedClusters/networkProfile.podCidr')))]",
+                    "equals": true
+                  }
+                },
+                "equals": 0
+              },
+              {
+                "allOf": [
+                  {
+                    "value": "[parameters('enforceServiceCidr')]",
+                    "equals": true
+                  },
+                  {
+                    "count": {
+                      "value": "[parameters('allowedServiceCidrRanges')]",
+                      "name": "allowedServiceCidrRange",
+                      "where": {
+                        "value": "[if(empty(field('Microsoft.ContainerService/managedClusters/networkProfile.serviceCidr')), bool('false'), ipRangeContains(current('allowedServiceCidrRange'), field('Microsoft.ContainerService/managedClusters/networkProfile.serviceCidr')))]",
+                        "equals": true
+                      }
+                    },
+                    "equals": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_enforce_aks_cidrs.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_enforce_aks_cidrs.json
@@ -29,7 +29,7 @@
           "displayName": "Enforce Service CIDR",
           "description": "When true, AKS serviceCidr must be fully contained in the allowed Service CIDR range."
         },
-        "defaultValue": false
+        "defaultValue": true
       },
       "allowedServiceCidrRanges": {
         "type": "Array",
@@ -65,15 +65,31 @@
           {
             "anyOf": [
               {
-                "count": {
-                  "value": "[parameters('allowedPodCidrRanges')]",
-                  "name": "allowedPodCidrRange",
-                  "where": {
-                    "value": "[if(empty(field('Microsoft.ContainerService/managedClusters/networkProfile.podCidr')), bool('false'), ipRangeContains(current('allowedPodCidrRange'), field('Microsoft.ContainerService/managedClusters/networkProfile.podCidr')))]",
-                    "equals": true
+                "allOf": [
+                  {
+                    "anyOf": [
+                      {
+                        "field": "Microsoft.ContainerService/managedClusters/networkProfile.networkPlugin",
+                        "equals": "kubenet"
+                      },
+                      {
+                        "value": "[not(empty(field('Microsoft.ContainerService/managedClusters/networkProfile.podCidr')))]",
+                        "equals": true
+                      }
+                    ]
+                  },
+                  {
+                    "count": {
+                      "value": "[parameters('allowedPodCidrRanges')]",
+                      "name": "allowedPodCidrRange",
+                      "where": {
+                        "value": "[if(empty(field('Microsoft.ContainerService/managedClusters/networkProfile.podCidr')), bool('false'), ipRangeContains(current('allowedPodCidrRange'), field('Microsoft.ContainerService/managedClusters/networkProfile.podCidr')))]",
+                        "equals": true
+                      }
+                    },
+                    "equals": 0
                   }
-                },
-                "equals": 0
+                ]
               },
               {
                 "allOf": [

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -71,10 +71,16 @@ locals {
           VNet-DNS-Settings = var.VNet-DNS-Settings
         },
         Enforce-AKS-CIDRs = {
-          allowedPodCidrRanges     = ["10.10.0.0/16"],
-          enforceServiceCidr       = true,
-          allowedServiceCidrRanges = ["10.20.0.0/16"],
-          effect                   = "Deny",
+          allowedPodCidrRanges = [
+            "10.10.0.0/18",
+            "10.10.128.0/18"
+          ],
+          enforceServiceCidr = true,
+          allowedServiceCidrRanges = [
+            "10.10.64.0/22",
+            "10.10.192.0/22"
+          ],
+          effect = "Deny",
         },
         Deny-Delete-NetworkWatch = {
           Network-Watcher-storageId           = "/subscriptions/${var.subscription_id_management}/resourceGroups/${var.network_watcher_storage_account_resource_group}/providers/Microsoft.Storage/storageAccounts/${var.network_watcher_storage_account_name}"

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -72,7 +72,7 @@ locals {
         },
         Enforce-AKS-CIDRs = {
           allowedPodCidrRanges     = ["10.10.0.0/16"],
-          enforceServiceCidr       = false,
+          enforceServiceCidr       = true,
           allowedServiceCidrRanges = ["10.20.0.0/16"],
           effect                   = "Deny",
         },

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -66,6 +66,12 @@ locals {
         Deny-VNet-DNS-Changes = {
           VNet-DNS-Settings = var.VNet-DNS-Settings
         },
+        Enforce-AKS-CIDRs = {
+          allowedPodCidrRanges     = ["10.10.0.0/16"],
+          enforceServiceCidr       = false,
+          allowedServiceCidrRanges = ["10.20.0.0/16"],
+          effect                   = "Deny",
+        },
         Deny-Delete-NetworkWatch = {
           Network-Watcher-storageId           = "/subscriptions/${var.subscription_id_management}/resourceGroups/${var.network_watcher_storage_account_resource_group}/providers/Microsoft.Storage/storageAccounts/${var.network_watcher_storage_account_name}"
           Network-Watcher-workspaceResourceId = "/subscriptions/${var.subscription_id_management}/resourceGroups/${var.root_id}-mgmt/providers/Microsoft.OperationalInsights/workspaces/${var.root_id}-la"


### PR DESCRIPTION
This pull request introduces several new Azure policy definitions and assignments to strengthen Kubernetes (AKS) security and compliance in the landing zones. The main focus is on enforcing CIDR ranges for AKS clusters, aligning with CIS benchmarks, and promoting best practices. It also extends the configuration options for these policies in the archetype extension templates and settings.

**AKS Policy Enhancements and Enforcement:**

* Added a new custom policy definition `Enforce-AKS-CIDRs` to restrict AKS Pod and Service CIDR ranges, with configurable parameters for allowed ranges and enforcement effect.
* Created a policy assignment for `Enforce-AKS-CIDRs` with specific allowed Pod and Service CIDR ranges and set the enforcement mode to "Deny".
* Updated archetype extension templates (`archetype_extension_es_landing_zones.tmpl.json`, `archetype_extension_es_root.tmpl.json`) to reference and parameterize the new `Enforce-AKS-CIDRs` policy, allowing overrides via configuration. [[1]](diffhunk://#diff-1793ace63156162ac6f68e852ccaefbe296954a103535746a486a9fc4a19fde7R13) [[2]](diffhunk://#diff-1793ace63156162ac6f68e852ccaefbe296954a103535746a486a9fc4a19fde7R57-R62) [[3]](diffhunk://#diff-c49f9b96b241f6a595d2811ff250bf40baf90d83141e3b78e8350cf158819735R35)
* Set default values for `Enforce-AKS-CIDRs` policy parameters in `settings.core.tf` for consistent enforcement across environments.

**Kubernetes Compliance and Best Practices:**

* Added policy assignments for AKS CIS Benchmark (`AKS-CIS-Benchmark`) and AKS Best Practices (`AKS-Best-Practices`), and included them in the root archetype extension template for broader compliance coverage. [[1]](diffhunk://#diff-ae949e6084d7cb95dc31763e7870547a09a3c3e817112f9027afe577d87b7466R1-R21) [[2]](diffhunk://#diff-4ce243485806d7312943935d892bea4c75059538cb39bd5e3db877d5dae70ce7R1-R41) [[3]](diffhunk://#diff-c49f9b96b241f6a595d2811ff250bf40baf90d83141e3b78e8350cf158819735L15-R17)
* Introduced a policy assignment for `Enforce-Guardrails-AKS` to ensure Kubernetes clusters adhere to regulated landing zone guardrails.