### PR TITLE
AMBA quarterly updates

### DIFF
--- a/azure_monitor_baseline_alerts/README.md
+++ b/azure_monitor_baseline_alerts/README.md
@@ -21,7 +21,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_amba_alz"></a> [amba\_alz](#module\_amba\_alz) | Azure/avm-ptn-monitoring-amba-alz/azurerm | 0.3.0 |
-| <a name="module_amba_policy"></a> [amba\_policy](#module\_amba\_policy) | Azure/avm-ptn-alz/azurerm | 0.19.0 |
+| <a name="module_amba_policy"></a> [amba\_policy](#module\_amba\_policy) | Azure/avm-ptn-alz/azurerm | 0.19.1 |
 
 ## Resources
 

--- a/azure_monitor_baseline_alerts/main.tf
+++ b/azure_monitor_baseline_alerts/main.tf
@@ -15,7 +15,7 @@ module "amba_alz" {
 
 module "amba_policy" {
   source             = "Azure/avm-ptn-alz/azurerm"
-  version            = "0.19.0"
+  version            = "0.19.1"
   architecture_name  = var.architecture_name
   location           = var.location
   parent_resource_id = var.parent_resource_id


### PR DESCRIPTION
This pull request updates the `amba_policy` module to use the latest patch version (`0.19.1`) in both the documentation and the Terraform configuration. This ensures consistency and brings in any bug fixes or minor improvements from the updated module version.

**Module version update:**

* Updated the `amba_policy` module version from `0.19.0` to `0.19.1` in the `azure_monitor_baseline_alerts/README.md` documentation.
* Updated the `amba_policy` module version from `0.19.0` to `0.19.1` in the `azure_monitor_baseline_alerts/main.tf` Terraform configuration.