### PR TITLE
SQL Managed Instances (MI) Policies for Entra AuthN and Private Data Endpoint

### DIFF
--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
@@ -14,7 +14,9 @@
       "MicrosoftCISv2",
       "NIST-SP-800-53-Rev5",
       "AKS-CIS-Benchmark",
-      "AKS-Best-Practices"
+      "AKS-Best-Practices",
+      "SQLMI-Entra-AuthN",
+      "SQLMI-Disable-PublicData"
     ],
     "policy_definitions": [
       "Inherit-Account-Code-Tag",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_disable_public_data_endpoint.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_disable_public_data_endpoint.json
@@ -1,0 +1,25 @@
+{
+  "name": "SQLMI-Disable-PublicData",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2024-04-01",
+  "properties": {
+    "displayName": "Azure SQL Managed Instances should disable public network access",
+    "description": "Disabling public network access (public endpoint) on Azure SQL Managed Instances improves security by ensuring that they can only be accessed from inside their virtual networks or via Private Endpoints. To learn more about public network access, visit https://aka.ms/mi-public-endpoint.",
+    "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9dfea752-dd46-4766-aed1-c355fa93fb91",
+    "metadata": {},
+    "notScopes": [],
+    "parameters": {},
+    "nonComplianceMessages": [
+        {
+          "message": "Azure SQL Managed Instance does not have Microsoft Entra-only authentication enabled. Please enable Microsoft Entra-only authentication to enhance security by allowing access exclusively via Microsoft Entra identities, which supports modern authentication features such as MFA, SSO, and secret-less programmatic access with managed identities."
+        }
+    ],
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default",
+    "overrides": []
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_disable_public_data_endpoint.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_disable_public_data_endpoint.json
@@ -11,7 +11,7 @@
     "parameters": {},
     "nonComplianceMessages": [
         {
-          "message": "Azure SQL Managed Instance does not have Microsoft Entra-only authentication enabled. Please enable Microsoft Entra-only authentication to enhance security by allowing access exclusively via Microsoft Entra identities, which supports modern authentication features such as MFA, SSO, and secret-less programmatic access with managed identities."
+          "message": "Azure SQL Managed Instance should have data access for clients outside of the connected virtual networks (public endpoint (data)) disabled. This means that the SQL Managed Instance can only be accessed from inside its virtual network or via Private Endpoints, and cannot be accessed over the internet."
         }
     ],
     "scope": "${current_scope_resource_id}",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_entra_authentication.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_entra_authentication.json
@@ -1,0 +1,25 @@
+{
+  "name": "SQLMI-Entra-AuthN",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2024-04-01",
+  "properties": {
+    "displayName": "Azure SQL Managed Instance should have Microsoft Entra-only authentication",
+    "description": "Require Microsoft Entra-only authentication for Azure SQL Managed instance, disabling local authentication methods. This allows access exclusively via Microsoft Entra identities, enhancing security with modern authentication enhancements including MFA, SSO, and secret-less programmatic access with managed identities.",
+    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/9b8d8228-e8cc-4c95-8d98-47f32df40b5e",
+    "metadata": {},
+    "notScopes": [],
+    "parameters": {},
+    "nonComplianceMessages": [
+        {
+          "message": "Azure SQL Managed Instance does not have Microsoft Entra-only authentication enabled. Please enable Microsoft Entra-only authentication to enhance security by allowing access exclusively via Microsoft Entra identities, which supports modern authentication features such as MFA, SSO, and secret-less programmatic access with managed identities."
+        }
+    ],
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default",
+    "overrides": []
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_entra_authentication.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_sql_mi_entra_authentication.json
@@ -4,7 +4,7 @@
   "apiVersion": "2024-04-01",
   "properties": {
     "displayName": "Azure SQL Managed Instance should have Microsoft Entra-only authentication",
-    "description": "Require Microsoft Entra-only authentication for Azure SQL Managed instance, disabling local authentication methods. This allows access exclusively via Microsoft Entra identities, enhancing security with modern authentication enhancements including MFA, SSO, and secret-less programmatic access with managed identities.",
+    "description": "Require Microsoft Entra-only authentication for Azure SQL Managed Instance, disabling local authentication methods. This allows access exclusively via Microsoft Entra identities, enhancing security with modern authentication enhancements including MFA, SSO, and secret-less programmatic access with managed identities.",
     "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/9b8d8228-e8cc-4c95-8d98-47f32df40b5e",
     "metadata": {},
     "notScopes": [],


### PR DESCRIPTION
This pull request introduces two new Azure policy assignments focused on improving the security of Azure SQL Managed Instances. The changes ensure that public network access is disabled and that Microsoft Entra-only authentication is enforced. Additionally, the root archetype extension is updated to include these new policies.

New Azure SQL Managed Instance security policies:

* Added `policy_assignment_sql_mi_entra_authentication.json` to enforce Microsoft Entra-only authentication for Azure SQL Managed Instances, requiring access exclusively via Entra identities and modern authentication features.
* Added `policy_assignment_sql_mi_disable_public_data_endpoint.json` to require that public network access is disabled for Azure SQL Managed Instances, ensuring access is only possible from within virtual networks or via Private Endpoints.

Archetype extension updates:

* Updated `archetype_extension_es_root.tmpl.json` to include the new `SQLMI-Entra-AuthN` and `SQLMI-Disable-PublicData` policy assignments in the list of policy sets.