### PR TITLE
Migrate from `Azure/lz-vending/azurerm` to `Azure/avm-ptn-alz-sub-vending/azure`

### DIFF
--- a/azure_ad_groups/README.md
+++ b/azure_ad_groups/README.md
@@ -35,9 +35,9 @@ This prevents accumulating old admins as group owners over time.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.59.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 
 ## Modules
 
@@ -52,6 +52,8 @@ No modules.
 | [azurerm_role_assignment.group_roles](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [null_resource.admin_owner](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
+| [azuread_group.existing](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_groups.existing](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/groups) | data source |
 | [azuread_users.members](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/users) | data source |
 
 ## Inputs

--- a/azure_ad_groups/README.md
+++ b/azure_ad_groups/README.md
@@ -48,9 +48,9 @@ If you previously used the `azuread_group_member` resource version of this modul
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.7.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.59.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
 

--- a/azure_ad_groups/README.md
+++ b/azure_ad_groups/README.md
@@ -4,24 +4,37 @@ Creates Azure AD groups (Owners, Contributors, Readers) for a project set and as
 
 ## Group owners behaviour
 
-Groups are created with the **Terraform execution identity** and **admin email** user as initial owners.
+Groups always include the **Terraform execution identity** and the current **admin email** user as owners.
 
 **Key behaviour:**
 
-- **Portal-added owners are preserved** – After creation, Terraform uses `lifecycle { ignore_changes = [owners] }` so owners added in the Azure portal (e.g. Technical Leads, managed identities for CI/CD) are never removed.
+- **Current owners are preserved** - Existing owners already on the group are read and merged into the desired owner list.
+- **`admin_email` is re-added if the user exists** - If the current admin user exists in Entra ID and is removed outside Terraform, the next plan/apply adds them back.
+- **Missing `admin_email` users are ignored** - If the configured `admin_email` does not resolve to an Entra user, the module skips that owner rather than failing the user lookup.
+- **Portal-added owners are preserved** - Owners added outside Terraform remain owners because the module merges them into the desired owner set rather than replacing them.
 
-- **Admin email changes are handled automatically** – When `admin_email` changes, a `null_resource` with triggers:
-  1. Removes the **old** admin email user as owner (using the value stored in Terraform state)
-  2. Adds the **new** admin email user as owner
-
-This prevents accumulating old admins as group owners over time.
-
-**Edge case:** If the old admin is the **only** owner of a group, Azure AD will not allow removal (minimum 1 owner required). In this case, the new admin is added but the old admin remains. You may need to manually remove the old admin after ensuring other owners exist.
+**Admin change behaviour:** If `admin_email` changes, the new admin is added automatically. The previous admin may remain as an owner and can be removed manually if desired.
 
 **Requirements:**
 
 - Azure CLI (`az`) must be installed and authenticated where Terraform runs.
 - The `hashicorp/null` provider (~> 3.0) is required.
+
+## Group members behaviour
+
+Group members are managed in an **add-only** manner using Azure CLI calls from Terraform.
+
+**Key behaviour:**
+
+- **Pre-existing members are preserved** - If a desired user is already a direct member of the target group, Terraform detects that and skips the add.
+- **Missing desired members are added** - If a desired user is not yet a member, Terraform adds them during apply.
+- **Members are not removed automatically** - Removing a user from module inputs does not remove them from the Entra group.
+
+This avoids failures when memberships already exist in Entra ID but were never imported into Terraform state.
+
+**Migration note:**
+
+If you previously used the `azuread_group_member` resource version of this module, remove those membership instances from Terraform state before applying this version. Otherwise Terraform will plan to destroy the old `azuread_group_member` resources as part of the transition to `null_resource.group_members`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -48,9 +61,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuread_group.groups](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group) | resource |
-| [azuread_group_member.group_members](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group_member) | resource |
 | [azurerm_role_assignment.group_roles](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [null_resource.admin_owner](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.group_members](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_group.existing](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_groups.existing](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/groups) | data source |

--- a/azure_ad_groups/main.tf
+++ b/azure_ad_groups/main.tf
@@ -56,7 +56,6 @@ locals {
   existing_groups = {
     for group_key, group in local.groups :
     group_key => {
-      name      = group.name
       object_id = local.existing_group_object_id_by_name[group.name]
     }
     if contains(keys(local.existing_group_object_id_by_name), group.name)
@@ -83,10 +82,7 @@ locals {
       member           = item.member
       member_object_id = local.member_id_by_upn[lower(item.member)]
     }
-    if contains(keys(local.member_id_by_upn), lower(item.member)) && !contains(
-      try(data.azuread_group.existing[item.group_key].members, []),
-      local.member_id_by_upn[lower(item.member)]
-    )
+    if contains(keys(local.member_id_by_upn), lower(item.member))
   }
 
   # Terraform-defined owners: admin_email + Terraform execution identity
@@ -107,8 +103,8 @@ data "azuread_users" "members" {
   user_principal_names = length(local.all_members) > 0 ? local.all_members : []
 }
 
-# Read any matching pre-existing groups so we can avoid recreating memberships
-# that already exist outside Terraform state.
+# Read any matching pre-existing groups so required owners can be merged with
+# current owners without removing owners that were added outside Terraform.
 data "azuread_groups" "existing" {
   display_names    = local.desired_group_names
   ignore_missing   = true
@@ -122,123 +118,61 @@ data "azuread_group" "existing" {
 }
 
 # Create the groups
-# lifecycle.ignore_changes on owners prevents Terraform from overwriting owners
-# added outside Terraform (e.g. Technical Leads, managed identities in the portal).
-# Admin email changes are handled by the null_resource.admin_owner below.
+# Preserve existing owners while always ensuring the current admin_email and
+# Terraform execution identity remain owners of every group.
 resource "azuread_group" "groups" {
   for_each         = local.groups
   display_name     = each.value.name
   security_enabled = true
   description      = each.value.description
-  owners           = local.terraform_owner_ids
-
-  lifecycle {
-    ignore_changes = [owners]
-  }
+  owners = distinct(concat(
+    try(data.azuread_group.existing[each.key].owners, []),
+    local.terraform_owner_ids
+  ))
 }
 
-# Manage admin_email owner lifecycle across all groups.
-# When admin_email changes:
-#   1. DESTROY provisioner fires with OLD admin_email from state -> removes old admin as owner
-#   2. Resource is recreated with new triggers
-#   3. CREATE provisioner fires with NEW admin_email -> adds new admin as owner
-# Portal-added owners are never touched (ignore_changes on azuread_group.owners).
-resource "null_resource" "admin_owner" {
-  for_each = local.groups
+# Add users to groups in an add-only manner.
+# This avoids failures when a desired membership already exists in Entra ID
+# outside Terraform state, and it does not remove members when they are later
+# removed from Terraform inputs.
+resource "null_resource" "group_members" {
+  for_each = local.existing_group_members
 
   triggers = {
-    admin_email = var.admin_email
-    group_name  = each.value.name
+    group_key        = each.value.group_key
+    group_name       = local.groups[each.value.group_key].name
+    group_object_id  = azuread_group.groups[each.value.group_key].id
+    member           = each.value.member
+    member_object_id = each.value.member_object_id
   }
 
-  # When admin_email changes, this fires FIRST with the OLD values from state
-  provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOT
-      set -e
-      echo "Removing old admin '${self.triggers.admin_email}' from group '${self.triggers.group_name}'..."
-
-      OLD_ADMIN_ID=$(az ad user show --id "${self.triggers.admin_email}" --query id -o tsv 2>/dev/null || true)
-      if [ -z "$OLD_ADMIN_ID" ] || [ "$OLD_ADMIN_ID" = "None" ]; then
-        echo "Old admin user not found in Azure AD, skipping removal."
-        exit 0
-      fi
-
-      GROUP_ID=$(az ad group list --display-name "${self.triggers.group_name}" --query "[0].id" -o tsv 2>/dev/null || true)
-      if [ -z "$GROUP_ID" ] || [ "$GROUP_ID" = "None" ]; then
-        echo "Group not found in Azure AD, skipping removal."
-        exit 0
-      fi
-
-      # Check if this user is actually an owner
-      IS_OWNER=$(az ad group owner list --group "$GROUP_ID" --query "[?id=='$OLD_ADMIN_ID'].id" -o tsv 2>/dev/null || true)
-      if [ -z "$IS_OWNER" ]; then
-        echo "Old admin is not currently an owner of this group, skipping removal."
-        exit 0
-      fi
-
-      # Check owner count - Azure requires at least 1 owner
-      OWNER_COUNT=$(az ad group owner list --group "$GROUP_ID" --query "length(@)" -o tsv 2>/dev/null || echo "0")
-      if [ "$OWNER_COUNT" -le 1 ]; then
-        echo "WARNING: Cannot remove old admin - they are the only owner. Azure requires at least 1 owner."
-        echo "The new admin will be added, then you may need to manually remove the old admin."
-        exit 0
-      fi
-
-      echo "Removing old admin (ID: $OLD_ADMIN_ID) from group (ID: $GROUP_ID)..."
-      if az ad group owner remove --group "$GROUP_ID" --owner-object-id "$OLD_ADMIN_ID"; then
-        echo "Successfully removed old admin from group."
-      else
-        echo "ERROR: Failed to remove old admin. Check permissions."
-        exit 1
-      fi
-    EOT
-  }
-
-  # Then this fires with the NEW admin_email
   provisioner "local-exec" {
     command = <<-EOT
       set -e
-      echo "Adding new admin '${self.triggers.admin_email}' to group '${self.triggers.group_name}'..."
+      echo "Ensuring member '${self.triggers.member}' is in group '${self.triggers.group_name}'..."
 
-      NEW_ADMIN_ID=$(az ad user show --id "${self.triggers.admin_email}" --query id -o tsv 2>/dev/null || true)
-      if [ -z "$NEW_ADMIN_ID" ] || [ "$NEW_ADMIN_ID" = "None" ]; then
-        echo "ERROR: New admin user '${self.triggers.admin_email}' not found in Azure AD."
-        exit 1
-      fi
+      IS_MEMBER=$(az ad group member check \
+        --group "${self.triggers.group_object_id}" \
+        --member-id "${self.triggers.member_object_id}" \
+        --query value -o tsv 2>/dev/null || echo "false")
 
-      GROUP_ID=$(az ad group list --display-name "${self.triggers.group_name}" --query "[0].id" -o tsv 2>/dev/null || true)
-      if [ -z "$GROUP_ID" ] || [ "$GROUP_ID" = "None" ]; then
-        echo "ERROR: Group '${self.triggers.group_name}' not found in Azure AD."
-        exit 1
-      fi
-
-      # Check if already an owner
-      IS_OWNER=$(az ad group owner list --group "$GROUP_ID" --query "[?id=='$NEW_ADMIN_ID'].id" -o tsv 2>/dev/null || true)
-      if [ -n "$IS_OWNER" ]; then
-        echo "New admin is already an owner of this group, skipping add."
+      if [ "$IS_MEMBER" = "true" ]; then
+        echo "Member is already in the group, skipping add."
         exit 0
       fi
 
-      echo "Adding new admin (ID: $NEW_ADMIN_ID) to group (ID: $GROUP_ID)..."
-      if az ad group owner add --group "$GROUP_ID" --owner-object-id "$NEW_ADMIN_ID"; then
-        echo "Successfully added new admin to group."
+      if az ad group member add \
+        --group "${self.triggers.group_object_id}" \
+        --member-id "${self.triggers.member_object_id}"; then
+        echo "Successfully added member to group."
       else
-        echo "ERROR: Failed to add new admin. Check permissions."
+        echo "ERROR: Failed to add member to group. Check permissions."
         exit 1
       fi
     EOT
   }
 
   depends_on = [azuread_group.groups]
-}
-
-# Add users to groups (only for users that actually exist)
-resource "azuread_group_member" "group_members" {
-  for_each = local.existing_group_members
-
-  group_object_id  = azuread_group.groups[each.value.group_key].id
-  member_object_id = each.value.member_object_id
 }
 
 # Assign roles to groups

--- a/azure_ad_groups/main.tf
+++ b/azure_ad_groups/main.tf
@@ -20,6 +20,8 @@ locals {
     }
   }
 
+  desired_group_names = [for _, group in local.groups : group.name]
+
   # Privileged Role IDs:
   # 8e3af657a8ff443ca75c2fe8c4bcb635 = Owner
   # b24988ac6180420aab8820f7382dd24c = Contributor
@@ -46,6 +48,20 @@ locals {
     data.azuread_users.members.object_ids
   ) : {}
 
+  existing_group_object_id_by_name = length(data.azuread_groups.existing.display_names) > 0 ? zipmap(
+    data.azuread_groups.existing.display_names,
+    data.azuread_groups.existing.object_ids
+  ) : {}
+
+  existing_groups = {
+    for group_key, group in local.groups :
+    group_key => {
+      name      = group.name
+      object_id = local.existing_group_object_id_by_name[group.name]
+    }
+    if contains(keys(local.existing_group_object_id_by_name), group.name)
+  }
+
   # Build raw list of all group-member pairs
   raw_group_members = flatten([
     for group_key, group in local.groups : [
@@ -67,7 +83,10 @@ locals {
       member           = item.member
       member_object_id = local.member_id_by_upn[lower(item.member)]
     }
-    if contains(keys(local.member_id_by_upn), lower(item.member))
+    if contains(keys(local.member_id_by_upn), lower(item.member)) && !contains(
+      try(data.azuread_group.existing[item.group_key].members, []),
+      local.member_id_by_upn[lower(item.member)]
+    )
   }
 
   # Terraform-defined owners: admin_email + Terraform execution identity
@@ -86,6 +105,20 @@ data "azuread_client_config" "current" {}
 data "azuread_users" "members" {
   ignore_missing       = true
   user_principal_names = length(local.all_members) > 0 ? local.all_members : []
+}
+
+# Read any matching pre-existing groups so we can avoid recreating memberships
+# that already exist outside Terraform state.
+data "azuread_groups" "existing" {
+  display_names    = local.desired_group_names
+  ignore_missing   = true
+  security_enabled = true
+}
+
+data "azuread_group" "existing" {
+  for_each = local.existing_groups
+
+  object_id = each.value.object_id
 }
 
 # Create the groups

--- a/terraform-azure-lz-project-set/README.md
+++ b/terraform-azure-lz-project-set/README.md
@@ -10,29 +10,29 @@ For each environment, the module will create a subscription, a network resource 
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | 2.7.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.54.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.54.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
-| <a name="module_lz_vending"></a> [lz\_vending](#module\_lz\_vending) | Azure/lz-vending/azurerm | 7.0.3 |
+| ---- | ------ | ------- |
+| <a name="module_lz_vending"></a> [lz\_vending](#module\_lz\_vending) | Azure/avm-ptn-alz-sub-vending/azure | 0.2.1 |
 | <a name="module_network_flow_logs"></a> [network\_flow\_logs](#module\_network\_flow\_logs) | Azure/avm-res-network-networkwatcher/azurerm | 0.3.0 |
-| <a name="module_resourceproviders_alerts_management"></a> [resourceproviders\_alerts\_management](#module\_resourceproviders\_alerts\_management) | Azure/lz-vending/azurerm//modules/resourceprovider | 7.0.3 |
-| <a name="module_resourceproviders_insights"></a> [resourceproviders\_insights](#module\_resourceproviders\_insights) | Azure/lz-vending/azurerm//modules/resourceprovider | 7.0.3 |
+| <a name="module_resourceproviders_alerts_management"></a> [resourceproviders\_alerts\_management](#module\_resourceproviders\_alerts\_management) | Azure/avm-ptn-alz-sub-vending/azure//modules/resource-provider | 0.2.1 |
+| <a name="module_resourceproviders_insights"></a> [resourceproviders\_insights](#module\_resourceproviders\_insights) | Azure/avm-ptn-alz-sub-vending/azure//modules/resource-provider | 0.2.1 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_consumption_budget_subscription.subscription_budget](https://registry.terraform.io/providers/hashicorp/azurerm/4.54.0/docs/resources/consumption_budget_subscription) | resource |
 | [azurerm_management_group.project_set](https://registry.terraform.io/providers/hashicorp/azurerm/4.54.0/docs/resources/management_group) | resource |
 | [azurerm_network_manager_ipam_pool_static_cidr.reservations](https://registry.terraform.io/providers/hashicorp/azurerm/4.54.0/docs/resources/network_manager_ipam_pool_static_cidr) | resource |
@@ -42,7 +42,7 @@ For each environment, the module will create a subscription, a network resource 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tags to apply to all resources | `map(string)` | <pre>{<br/>  "deployedBy": "Terraform"<br/>}</pre> | no |
 | <a name="input_deny_vnet_address_change_policy_definition_id"></a> [deny\_vnet\_address\_change\_policy\_definition\_id](#input\_deny\_vnet\_address\_change\_policy\_definition\_id) | The ID of the policy definition to deny changes to virtual network address spaces | `string` | `null` | no |
 | <a name="input_license_plate"></a> [license\_plate](#input\_license\_plate) | The license plate identifier for the project | `string` | n/a | yes |
@@ -61,7 +61,7 @@ For each environment, the module will create a subscription, a network resource 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_management_group_id"></a> [management\_group\_id](#output\_management\_group\_id) | The management group ID for the project set. |
 | <a name="output_subscription_ids"></a> [subscription\_ids](#output\_subscription\_ids) | The subscription IDs of each landing zone created. |
 <!-- END_TF_DOCS -->

--- a/terraform-azure-lz-project-set/README.md
+++ b/terraform-azure-lz-project-set/README.md
@@ -10,20 +10,20 @@ For each environment, the module will create a subscription, a network resource 
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | 2.7.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.54.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.54.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_lz_vending"></a> [lz\_vending](#module\_lz\_vending) | Azure/avm-ptn-alz-sub-vending/azure | 0.2.1 |
 | <a name="module_network_flow_logs"></a> [network\_flow\_logs](#module\_network\_flow\_logs) | Azure/avm-res-network-networkwatcher/azurerm | 0.3.0 |
 | <a name="module_resourceproviders_alerts_management"></a> [resourceproviders\_alerts\_management](#module\_resourceproviders\_alerts\_management) | Azure/avm-ptn-alz-sub-vending/azure//modules/resource-provider | 0.2.1 |
@@ -32,7 +32,7 @@ For each environment, the module will create a subscription, a network resource 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [azurerm_consumption_budget_subscription.subscription_budget](https://registry.terraform.io/providers/hashicorp/azurerm/4.54.0/docs/resources/consumption_budget_subscription) | resource |
 | [azurerm_management_group.project_set](https://registry.terraform.io/providers/hashicorp/azurerm/4.54.0/docs/resources/management_group) | resource |
 | [azurerm_network_manager_ipam_pool_static_cidr.reservations](https://registry.terraform.io/providers/hashicorp/azurerm/4.54.0/docs/resources/network_manager_ipam_pool_static_cidr) | resource |
@@ -42,7 +42,7 @@ For each environment, the module will create a subscription, a network resource 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tags to apply to all resources | `map(string)` | <pre>{<br/>  "deployedBy": "Terraform"<br/>}</pre> | no |
 | <a name="input_deny_vnet_address_change_policy_definition_id"></a> [deny\_vnet\_address\_change\_policy\_definition\_id](#input\_deny\_vnet\_address\_change\_policy\_definition\_id) | The ID of the policy definition to deny changes to virtual network address spaces | `string` | `null` | no |
 | <a name="input_license_plate"></a> [license\_plate](#input\_license\_plate) | The license plate identifier for the project | `string` | n/a | yes |
@@ -61,7 +61,7 @@ For each environment, the module will create a subscription, a network resource 
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_management_group_id"></a> [management\_group\_id](#output\_management\_group\_id) | The management group ID for the project set. |
 | <a name="output_subscription_ids"></a> [subscription\_ids](#output\_subscription\_ids) | The subscription IDs of each landing zone created. |
 <!-- END_TF_DOCS -->

--- a/terraform-azure-lz-project-set/main.tf
+++ b/terraform-azure-lz-project-set/main.tf
@@ -27,8 +27,8 @@ resource "azurerm_management_group" "project_set" {
 }
 
 module "lz_vending" {
-  source  = "Azure/lz-vending/azurerm"
-  version = "7.0.3" # NOTE: When updating this version, please update the respective `resourceproviders_*` modules below
+  source  = "Azure/avm-ptn-alz-sub-vending/azure"
+  version = "0.2.1" # NOTE: When updating this version, please update the respective `resourceproviders_*` modules below
 
   for_each = var.subscriptions
 
@@ -67,7 +67,7 @@ module "lz_vending" {
       }
     }
   )
-  disable_telemetry = true
+  enable_telemetry = false
   virtual_networks = try(each.value.network.enabled, false) ? {
     vwan_spoke = {
       name = "${var.license_plate}-${each.value.name}-vwan-spoke"
@@ -140,8 +140,8 @@ resource "azurerm_consumption_budget_subscription" "subscription_budget" {
 
 # NOTE: This Resource Provider is required when using Azure Monitor Baseline Alerts (AMBA)
 module "resourceproviders_alerts_management" {
-  source  = "Azure/lz-vending/azurerm//modules/resourceprovider"
-  version = "7.0.3" # Should match the lz_vending module version
+  source  = "Azure/avm-ptn-alz-sub-vending/azure//modules/resource-provider"
+  version = "0.2.1" # Should match the avm-ptn-alz-sub-vending module version
 
   for_each = {
     for k, v in var.subscriptions : k => v
@@ -154,8 +154,8 @@ module "resourceproviders_alerts_management" {
 
 # NOTE: This Resource Provider is required when using Azure Monitor Baseline Alerts (AMBA)
 module "resourceproviders_insights" {
-  source  = "Azure/lz-vending/azurerm//modules/resourceprovider"
-  version = "7.0.3" # Should match the lz_vending module version
+  source  = "Azure/avm-ptn-alz-sub-vending/azure//modules/resource-provider"
+  version = "0.2.1" # Should match the avm-ptn-alz-sub-vending module version
 
   for_each = {
     for k, v in var.subscriptions : k => v


### PR DESCRIPTION
## Summary

- `lz_vending`, `resourceproviders_alerts_management`, and `resourceproviders_insights` now use `Azure/avm-ptn-alz-sub-vending/azure` (v0.2.1), the AVM-pattern replacement for the legacy `Azure/lz-vending/azurerm` (v7.0.3) module.
- Renamed `disable_telemetry = true` to `enable_telemetry = false` to match the new module's input.
- The resource-provider submodule path also moved from `modules/resourceprovider` to `modules/resource-provider`.
