### PR TITLE
Add DINE policy for Microsoft Fabric private DNS

### DIFF
--- a/caf_cccs_medium/modules/core/DINE_Private_DNS_Policy.md
+++ b/caf_cccs_medium/modules/core/DINE_Private_DNS_Policy.md
@@ -346,4 +346,5 @@ The CAF module provides these template variables for use in JSON files:
 | OpenAI | `Deploy-Private-DNS-OpenAI` | `policy_definition_deploy_private_dns_openai.json` |
 | Container Apps | `Deploy-Private-DNS-ACA` | `policy_definition_deploy_private_dns_containerapps.json` |
 | Azure Managed Redis | `Deploy-Private-DNS-Redis` | `policy_definition_deploy_private_dns_managed_redis.json` |
+| Microsoft Fabric | `Deploy-Private-DNS-Fbrc` | `policy_definition_deploy_private_dns_fabric.json` |
 | Many built-in services | _(bundled in initiative)_ | `policy_set_definition_es_deploy_private_dns_zones_custom.json` |

--- a/caf_cccs_medium/modules/core/DINE_Private_DNS_Policy.md
+++ b/caf_cccs_medium/modules/core/DINE_Private_DNS_Policy.md
@@ -346,5 +346,5 @@ The CAF module provides these template variables for use in JSON files:
 | OpenAI | `Deploy-Private-DNS-OpenAI` | `policy_definition_deploy_private_dns_openai.json` |
 | Container Apps | `Deploy-Private-DNS-ACA` | `policy_definition_deploy_private_dns_containerapps.json` |
 | Azure Managed Redis | `Deploy-Private-DNS-Redis` | `policy_definition_deploy_private_dns_managed_redis.json` |
-| Microsoft Fabric | `Deploy-Private-DNS-Fbrc` | `policy_definition_deploy_private_dns_fabric.json` |
+| Microsoft Fabric | `Deploy-Private-DNS-Fbrc` | `policy_definition_deploy_private_dns_fabric.json` _(definition only; currently wired through the shared initiative, not a standalone assignment + `settings.core.tf` override example)_ |
 | Many built-in services | _(bundled in initiative)_ | `policy_set_definition_es_deploy_private_dns_zones_custom.json` |

--- a/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
+++ b/caf_cccs_medium/modules/core/lib/archetype_extensions/archetype_extension_es_root.tmpl.json
@@ -25,6 +25,7 @@
       "Deploy-Private-DNS-CgSrv",
       "Deploy-Private-DNS-ACA",
       "Deploy-Private-DNS-Redis",
+      "Deploy-Private-DNS-Fbrc",
       "Deny-VNet-DNS-Changes",
       "Deny-Protected-Network-Resources",
       "Deny-Deleting-Protected-Route-Resources",

--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_es_deploy_private_dns_zones_custom.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_es_deploy_private_dns_zones_custom.json
@@ -215,6 +215,9 @@
         },
         "azureSiteRecoveryQueuePrivateDnsZoneId": {
           "value": "${private_dns_zone_prefix}privatelink.queue.core.windows.net"
+        },
+        "azureFabricPrivateDnsZoneId": {
+          "value": "${private_dns_zone_prefix}privatelink.fabric.microsoft.com"
         }
       },
       "scope": "${current_scope_resource_id}",

--- a/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deploy_private_dns_fabric.json
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/policy_definition_deploy_private_dns_fabric.json
@@ -1,0 +1,121 @@
+{
+  "name": "Deploy-Private-DNS-Fbrc",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "apiVersion": "2024-05-01",
+  "properties": {
+    "displayName": "Configure private DNS zones for private endpoints connected to Microsoft Fabric",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "description": "Use private DNS zones to override the DNS resolution for a private endpoint connected to Microsoft Fabric workspace-level private link services. A private DNS zone links to your virtual network to resolve to the Fabric workspace (privatelink.fabric.microsoft.com).",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Fabric"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "The effect of the policy.",
+          "strongType": "Effect",
+          "defaultValue": "DeployIfNotExists"
+        }
+      },
+      "fabricPrivateDnsZoneId": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Fabric Private DNS Zone ID",
+          "description": "The Private DNS Zone ID for Microsoft Fabric workspace-level private links (privatelink.fabric.microsoft.com).",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "equals": "Microsoft.Network/privateEndpoints",
+            "field": "type"
+          },
+          {
+            "count": {
+              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+              "where": {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                    "contains": "Microsoft.Fabric/privateLinkServicesForFabric"
+                  },
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                    "equals": "workspace"
+                  }
+                ]
+              }
+            },
+            "greaterOrEquals": 1
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+            "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+          ],
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "fabricPrivateDnsZoneId": {
+                  "value": "[parameters('fabricPrivateDnsZoneId')]"
+                },
+                "privateEndpointName": {
+                  "value": "[field('name')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                }
+              },
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "fabricPrivateDnsZoneId": {
+                    "type": "string"
+                  },
+                  "privateEndpointName": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "apiVersion": "2022-07-01",
+                    "location": "[parameters('location')]",
+                    "name": "[concat(parameters('privateEndpointName'), '/deployedByPolicy')]",
+                    "properties": {
+                      "privateDnsZoneConfigs": [
+                        {
+                          "name": "fabric-private-dns-zone",
+                          "properties": {
+                            "privateDnsZoneId": "[parameters('fabricPrivateDnsZoneId')]"
+                          }
+                        }
+                      ]
+                    },
+                    "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/caf_cccs_medium/modules/core/lib/policy_set_definitions/policy_set_definition_es_deploy_private_dns_zones_custom.json
+++ b/caf_cccs_medium/modules/core/lib/policy_set_definitions/policy_set_definition_es_deploy_private_dns_zones_custom.json
@@ -186,11 +186,21 @@
             "azureSynapseSQLODPrivateDnsZoneId": "privatelink.sql.azuresynapse.net",
             "azureVirtualDesktopHostpoolPrivateDnsZoneId": "privatelink.wvd.microsoft.com",
             "azureVirtualDesktopWorkspacePrivateDnsZoneId": "privatelink.wvd.microsoft.com",
-            "azureWebPrivateDnsZoneId": "privatelink.webpubsub.azure.com"
+            "azureWebPrivateDnsZoneId": "privatelink.webpubsub.azure.com",
+            "azureFabricPrivateDnsZoneId": "privatelink.fabric.microsoft.com"
           },
           "metadata": {
             "displayName": "DNS Zone Names",
             "description": "The list of private DNS zone names to be used for the Azure PaaS services."
+          }
+        },
+        "azureFabricPrivateDnsZoneId": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+            "displayName": "azureFabricPrivateDnsZoneId",
+            "strongType": "Microsoft.Network/privateDnsZones",
+            "description": "Private DNS Zone Identifier for Microsoft Fabric workspace-level private links (privatelink.fabric.microsoft.com)"
           }
         },
         "azureFilePrivateDnsZoneId": {
@@ -1715,6 +1725,19 @@
           },
           "groupNames": [],
           "definitionVersion": "1.*.*-preview"
+        },
+        {
+          "policyDefinitionReferenceId": "DINE-Private-DNS-Microsoft-Fabric",
+          "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Private-DNS-Fbrc",
+          "parameters": {
+            "fabricPrivateDnsZoneId": {
+              "value": "[if(equals(parameters('dnsZoneSubscriptionId'), ''), parameters('azureFabricPrivateDnsZoneId'), format('/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}', parameters('dnsZoneSubscriptionId'), toLower(parameters('dnsZoneResourceGroupName')), parameters('dnsZoneResourceType'), parameters('dnsZoneNames').azureFabricPrivateDnsZoneId))]"
+            },
+            "effect": {
+              "value": "[parameters('effect')]"
+            }
+          },
+          "groupNames": []
         }
       ],
       "policyDefinitionGroups": null


### PR DESCRIPTION
This pull request adds support for Microsoft Fabric private DNS zones to the core CAF module, ensuring that private endpoints for Microsoft Fabric can be automatically configured with the appropriate DNS zones. The changes introduce a new policy definition, update existing policy sets and assignments, and extend documentation and templates to include Microsoft Fabric.

**Microsoft Fabric Private DNS Zone Support**

* Added a new policy definition for deploying private DNS zones for Microsoft Fabric private endpoints in `policy_definition_deploy_private_dns_fabric.json`.
* Updated the policy set definition (`policy_set_definition_es_deploy_private_dns_zones_custom.json`) to:
  - Add parameters and default values for `azureFabricPrivateDnsZoneId`
  - Reference the new Fabric DNS policy in the policy definitions array
* Updated the policy assignment (`policy_assignment_es_deploy_private_dns_zones_custom.json`) to pass the new Fabric DNS zone variable.
* Extended the root archetype extension template to include the new Fabric DNS policy.
* Updated documentation to list Microsoft Fabric as a supported service for private DNS deployment.