### PR TITLE
AZR-160-appSlots

### DIFF
--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_public_paas_endpoints.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_public_paas_endpoints.json
@@ -25,6 +25,9 @@
       "AsPublicIpDenyEffect": {
         "value": "Disabled"
       },
+      "appSlotsPublicNetworkAccess":{
+        "value": "Disabled"
+      },
       "AsePublicIpDenyEffect": {
         "value": "Disabled"
       },


### PR DESCRIPTION
[AZR-160](https://citz-do.atlassian.net/browse/AZR-160)
This PR is to set appSlotsPublicNetworkAccess property to Disabled. In our Policy Assignment, we have the AsPublicIpDenyEffect property set to "Disabled". But the appSlotsPublicNetworkAccess property is not set in the shared Terraform modules [shared-terraform-modules](https://github.com/bcgov/azure-lz-terraform-modules/).