### PR TITLE
Azure Policy Lens - Fixes

### DIFF
--- a/azure_policy_lens/ps_modules/AzPolicyLens.Wiki/AzPolicyLens.Wiki.Markdown.Helper.psm1
+++ b/azure_policy_lens/ps_modules/AzPolicyLens.Wiki/AzPolicyLens.Wiki.Markdown.Helper.psm1
@@ -1220,8 +1220,8 @@ function buildPolicyDefinitionGroupComplianceCoverageMarkdown {
     $Markdown += "- <span style=`"color:#FF0000`">Red</span>: Below $ComplianceWarningPercentageThreshold%`n`n"
   } else {
     $Markdown += "- $(GetGitHubStatusLabel -ColorCode '#008000' -Text 'Green: 100%')`n"
-    $Markdown += "- $(GetGitHubStatusLabel -ColorCode '#FFA500' -Text \"Orange: Above $ComplianceWarningPercentageThreshold%\")`n"
-    $Markdown += "- $(GetGitHubStatusLabel -ColorCode '#FF0000' -Text \"Red: Below $ComplianceWarningPercentageThreshold%\")`n`n"
+    $Markdown += "- $(GetGitHubStatusLabel -ColorCode '#FFA500' -Text $('Orange: Above {0}%' -f $ComplianceWarningPercentageThreshold))`n"
+    $Markdown += "- $(GetGitHubStatusLabel -ColorCode '#FF0000' -Text $('Red: Below {0}%' -f $ComplianceWarningPercentageThreshold))`n`n"
   }
   $Markdown
 }
@@ -4157,8 +4157,8 @@ function buildExemptionExpiresOnMarkdown {
     $PageContent += "- <span style=`"color:#FFA500`">Orange</span>: Expires in less than $expiresOnWarningDays days.`n"
     $PageContent += "- <span style=`"color:#FF0000`">Red</span>: Already expired.`n`n"
   } else {
-    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#008000' -Text \"Green: Expires in more than $expiresOnWarningDays days.\")`n"
-    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#FFA500' -Text \"Orange: Expires in less than $expiresOnWarningDays days.\")`n"
+    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#008000' -Text $('Green: Expires in more than {0} days.' -f $expiresOnWarningDays))`n"
+    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#FFA500' -Text $('Orange: Expires in less than {0} days.' -f $expiresOnWarningDays))`n"
     $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#FF0000' -Text 'Red: Already expired.')"
     $PageContent += "`n`n"
   }
@@ -4184,8 +4184,8 @@ function buildComplianceRatingMarkdown {
     $PageContent += "- <span style=`"color:#FF0000`">Red</span>: < $ComplianceWarningPercentageThreshold%`n`n"
   } else {
     $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#008000' -Text 'Green: = 100%')`n"
-    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#FFA500' -Text \"Orange: >= $ComplianceWarningPercentageThreshold%\")`n"
-    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#FF0000' -Text \"Red: < $ComplianceWarningPercentageThreshold%\")`n`n"
+    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#FFA500' -Text $('Orange: >= {0}%' -f $ComplianceWarningPercentageThreshold))`n"
+    $PageContent += "- $(GetGitHubStatusLabel -ColorCode '#FF0000' -Text $('Red: < {0}%' -f $ComplianceWarningPercentageThreshold))`n`n"
   }
   $PageContent
 }

--- a/azure_policy_lens/ps_modules/AzPolicyLens.Wiki/AzPolicyLens.Wiki.Platform.Helper.psm1
+++ b/azure_policy_lens/ps_modules/AzPolicyLens.Wiki/AzPolicyLens.Wiki.Platform.Helper.psm1
@@ -351,6 +351,7 @@ function newWikiPageMapping {
   $config = @{
     BaseOutputPath         = $BaseOutputPath
     WikiStyle              = $WikiStyle
+    PageStyle              = $PageStyle
     AdoResourceDirectories = $adoResourceDirectories
   }
   #Process definitions
@@ -929,10 +930,14 @@ function getWikiPageFileName {
         $parent = getResourceParent -ResourceId $ResourceId
         if ($wikiFileMapping.WikiStyle -ieq 'ado') {
           $fileBaseName = encodeAdoWikiPageTitle -stringToEncode $resourceName
+          $effectivePageStyle = $wikiFileMapping.PageStyle
+          if ([string]::IsNullOrEmpty($effectivePageStyle)) {
+            $effectivePageStyle = 'detailed'
+          }
           if ($resolvedResourceType -ieq 'security_control') {
-            $fileDirectory = getPolicyResourceAdoDirectoryPath -ResourceId $ResourceId -BasePath $wikiFileMapping.BaseOutputPath -getResourceTypeRoot $true
+            $fileDirectory = getPolicyResourceAdoDirectoryPath -ResourceId $ResourceId -BasePath $wikiFileMapping.BaseOutputPath -getResourceTypeRoot $true -PageStyle $effectivePageStyle
           } else {
-            $fileDirectory = getPolicyResourceAdoDirectoryPath -ResourceId $ResourceId -BasePath $wikiFileMapping.BaseOutputPath
+            $fileDirectory = getPolicyResourceAdoDirectoryPath -ResourceId $ResourceId -BasePath $wikiFileMapping.BaseOutputPath -PageStyle $effectivePageStyle
           }
         } else {
           $fileBaseName = newGithubWikiPageBaseName -resourceName $resourceName -parent $parent -resourceType $resolvedResourceType

--- a/azure_policy_lens/ps_modules/AzPolicyLens.Wiki/AzPolicyLens.Wiki.Platform.Helper.psm1
+++ b/azure_policy_lens/ps_modules/AzPolicyLens.Wiki/AzPolicyLens.Wiki.Platform.Helper.psm1
@@ -910,7 +910,56 @@ function getWikiPageFileName {
   } elseif ($PSCmdlet.ParameterSetName -eq 'individual_azure_resource') {
     $mapping = $wikiFileMapping._resourceIdIndex[$ResourceId.ToLower()]
     if (!$mapping) {
-      Write-Error "No wiki page file name mapping found for resource '$ResourceId'."
+      $normalizedResourceId = $ResourceId.ToLower()
+      $resolvedResourceType = $null
+      if ($normalizedResourceId -match '/providers/microsoft\.authorization/policydefinitions/') {
+        $resolvedResourceType = 'definition'
+      } elseif ($normalizedResourceId -match '/providers/microsoft\.authorization/policysetdefinitions/') {
+        $resolvedResourceType = 'initiative'
+      } elseif ($normalizedResourceId -match '/providers/microsoft\.authorization/policyassignments/') {
+        $resolvedResourceType = 'assignment'
+      } elseif ($normalizedResourceId -match '/providers/microsoft\.authorization/policyexemptions/') {
+        $resolvedResourceType = 'exemption'
+      } elseif ($normalizedResourceId -match '/providers/microsoft\.policyinsights/policymetadata/') {
+        $resolvedResourceType = 'security_control'
+      }
+
+      if ($resolvedResourceType) {
+        $resourceName = ($ResourceId -split '/')[-1]
+        $parent = getResourceParent -ResourceId $ResourceId
+        if ($wikiFileMapping.WikiStyle -ieq 'ado') {
+          $fileBaseName = encodeAdoWikiPageTitle -stringToEncode $resourceName
+          if ($resolvedResourceType -ieq 'security_control') {
+            $fileDirectory = getPolicyResourceAdoDirectoryPath -ResourceId $ResourceId -BasePath $wikiFileMapping.BaseOutputPath -getResourceTypeRoot $true
+          } else {
+            $fileDirectory = getPolicyResourceAdoDirectoryPath -ResourceId $ResourceId -BasePath $wikiFileMapping.BaseOutputPath
+          }
+        } else {
+          $fileBaseName = newGithubWikiPageBaseName -resourceName $resourceName -parent $parent -resourceType $resolvedResourceType
+          $fileDirectory = $wikiFileMapping.BaseOutputPath
+        }
+
+        $fileName = '{0}.md' -f $fileBaseName
+        $mapping = @{
+          FileBaseName        = $fileBaseName
+          FileName            = $fileName
+          FileParentDirectory = $fileDirectory
+          FilePath            = Join-Path $fileDirectory $fileName
+          ResourceName        = $resourceName
+          ResourceId          = $ResourceId
+          ResourceType        = $resolvedResourceType
+          PageType            = 'individual'
+          Parent              = $parent
+        }
+
+        # Cache fallback mapping to avoid repeated regeneration for the same resource id.
+        $wikiFileMapping.FileMapping += $mapping
+        $wikiFileMapping._resourceIdIndex[$normalizedResourceId] = $mapping
+
+        Write-Warning "No pre-generated wiki page file name mapping found for resource '$ResourceId'. Generated fallback mapping using detected resource type '$resolvedResourceType'."
+      } else {
+        Write-Error "No wiki page file name mapping found for resource '$ResourceId'."
+      }
     }
   } elseif ($PSCmdlet.ParameterSetName -eq 'policy_category') {
     $mapping = $wikiFileMapping.FileMapping | Where-Object { $_.ResourceType -ieq 'policy_category' -and $_.PageType -ieq 'individual' }


### PR DESCRIPTION
This pull request introduces improvements to the markdown generation logic and enhances the robustness of the wiki page file name resolution for Azure Policy Lens. The main focus is on making the markdown label text formatting more consistent and user-friendly, and on providing a fallback mechanism for generating wiki page file names when a resource mapping is missing.

**Markdown generation improvements:**

* Updated the formatting of label text in the markdown output to use PowerShell string formatting (`-f`) rather than direct variable interpolation. This ensures that dynamic values such as `$ComplianceWarningPercentageThreshold` and `$expiresOnWarningDays` are always correctly inserted into the label text, improving clarity and consistency across compliance and exemption status labels. [[1]](diffhunk://#diff-e0827340a0befdd4456a594a12adeb31823984cdf9eccd216554f881e20bc9b1L1223-R1224) [[2]](diffhunk://#diff-e0827340a0befdd4456a594a12adeb31823984cdf9eccd216554f881e20bc9b1L4160-R4161) [[3]](diffhunk://#diff-e0827340a0befdd4456a594a12adeb31823984cdf9eccd216554f881e20bc9b1L4187-R4188)

**Wiki page file name resolution enhancements:**

* Added a fallback mechanism in `getWikiPageFileName` to dynamically generate a wiki page mapping for Azure Policy resources when a pre-generated mapping is not found. This includes logic to detect the resource type from the resource ID, construct the appropriate file and directory names, and cache the result for future lookups, improving reliability and reducing errors for unmapped resources.