### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -9,7 +9,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-fmt.yaml
+++ b/.github/workflows/terraform-fmt.yaml
@@ -5,8 +5,8 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v4
 
       - name: terraform fmt
         run: terraform fmt -check -recursive -diff


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflow dependencies to Node 24-compatible major versions.
- Replaces older action references such as `actions/checkout@v4`, `hashicorp/setup-terraform@v3`, `azure/login@v2`, and where present `tj-actions/changed-files@v46`.
- Keeps the change limited to workflow `uses:` references; no Terraform module or environment configuration is changed.

## Test plan
- Parsed all workflow YAML files successfully.
- Confirmed no targeted old action references remain in `.github/workflows`.
- Ran a CRLF-aware `git diff --check` for changed workflow files.
- Pre-commit hooks passed where configured.