### PR TITLE
Added provider alias for GitHub Managed Runner Resources

### DIFF
--- a/github_managed_runners_azure_vnet/gh_network_settings/README.md
+++ b/github_managed_runners_azure_vnet/gh_network_settings/README.md
@@ -1,5 +1,17 @@
 # gh_network_settings
 
+IMPORTANT: This module is created to be used in a centralized deployment within the Connectivity subscription. It has not been coded in a reusable way for other subscriptions.
+
+If, in the future, this module needs to be used in other Landing Zone subscriptions, certain assumptions would be made, including:
+
+- The target Virtual Network (VNet) already exists, and therefore no new IPAM reservations are needed
+- The VNet is already connected to the Virtual WAN Hub, and therefore no new Virtual Hub connections are needed
+- VNet flow logs are already configured
+- A Network Security Group (NSG) already exists and is associated with the target subnet (though additional rules will be required)
+- The target subnet already exists and is delegated to Microsoft.GitHub/hostedRunners
+
+Modification of this module would be required to support these assumptions, and the module would need to be refactored to support a more generic use case.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/github_managed_runners_azure_vnet/gh_network_settings/terraform.tf
+++ b/github_managed_runners_azure_vnet/gh_network_settings/terraform.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      source                = "hashicorp/azurerm"
+      version               = "~> 4.0"
+      configuration_aliases = [azurerm.connectivity]
     }
 
     azapi = {

--- a/github_managed_runners_azure_vnet/gh_network_settings/variables.common.tf
+++ b/github_managed_runners_azure_vnet/gh_network_settings/variables.common.tf
@@ -1,8 +1,3 @@
-# variable "subscription_id_management" {
-#   description = "(Required) Subscription ID to use for \"management\" resources."
-#   type        = string
-# }
-
 variable "subscription_id_connectivity" {
   type        = string
   description = "Subscription ID to use for \"connectivity\" resources."

--- a/github_managed_runners_azure_vnet/virtual_network/README.md
+++ b/github_managed_runners_azure_vnet/virtual_network/README.md
@@ -1,5 +1,17 @@
 # virtual_network
 
+IMPORTANT: This module is created to be used in a centralized deployment within the Connectivity subscription. It has not been coded in a reusable way for other subscriptions.
+
+If, in the future, this module needs to be used in other Landing Zone subscriptions, certain assumptions would be made, including:
+
+- The target Virtual Network (VNet) already exists, and therefore no new IPAM reservations are needed
+- The VNet is already connected to the Virtual WAN Hub, and therefore no new Virtual Hub connections are needed
+- VNet flow logs are already configured
+- A Network Security Group (NSG) already exists and is associated with the target subnet (though additional rules will be required)
+- The target subnet already exists and is delegated to Microsoft.GitHub/hostedRunners
+
+Modification of this module would be required to support these assumptions, and the module would need to be refactored to support a more generic use case.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/github_managed_runners_azure_vnet/virtual_network/nsg.tf
+++ b/github_managed_runners_azure_vnet/virtual_network/nsg.tf
@@ -1,4 +1,6 @@
 resource "azurerm_network_security_group" "github_hosted_runners_nsg" {
+  provider = azurerm.connectivity
+
   name                = var.github_hosted_runners_subnet_name
   location            = var.location
   resource_group_name = azurerm_resource_group.ghrunners.name

--- a/github_managed_runners_azure_vnet/virtual_network/resource.group.tf
+++ b/github_managed_runners_azure_vnet/virtual_network/resource.group.tf
@@ -1,4 +1,6 @@
 resource "azurerm_resource_group" "ghrunners" {
+  provider = azurerm.connectivity
+
   name     = var.virtual_network_resource_group_name
   location = var.location
 }

--- a/github_managed_runners_azure_vnet/virtual_network/virtual.network.tf
+++ b/github_managed_runners_azure_vnet/virtual_network/virtual.network.tf
@@ -1,4 +1,6 @@
 resource "azurerm_virtual_network" "ghrunners_vnet" {
+  provider = azurerm.connectivity
+
   name                           = var.virtual_network_name
   location                       = var.location
   resource_group_name            = azurerm_resource_group.ghrunners.name


### PR DESCRIPTION
This pull request updates the Azure provider configuration and resource definitions to ensure that network-related resources are explicitly created using the `connectivity` subscription. The main changes involve specifying the `azurerm.connectivity` provider alias for key resources and updating the provider block to support this alias.

**Provider configuration and usage updates:**

* Added `configuration_aliases = [azurerm.connectivity]` to the `azurerm` provider block in `terraform.tf` to enable use of the `connectivity` alias.
* Updated `azurerm_resource_group.ghrunners`, `azurerm_virtual_network.ghrunners_vnet`, and `azurerm_network_security_group.github_hosted_runners_nsg` resources to explicitly use the `azurerm.connectivity` provider, ensuring they are created in the correct subscription. [[1]](diffhunk://#diff-662aec77792a8f7e7e97f370d617dd78a5cd58d922d2b46a5f796873db570e8cR2-R3) [[2]](diffhunk://#diff-a96b5cdf2471bdfb5481054ecd85fa5395d3e14794dcbf1fa04f5c20e63b4670R2-R3) [[3]](diffhunk://#diff-16d9aa83556dc9fc4af65439da1ad88b42ac20e5189965653b0b68c029a13e38R2-R3)

**Variable and configuration cleanup:**

* Removed the commented-out `subscription_id_management` variable from `variables.common.tf`, leaving only the active `subscription_id_connectivity` variable.