### PR TITLE
Updated MS Fabric Messaging

### DIFF
--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_creating_fabric_capacity.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_creating_fabric_capacity.json
@@ -14,7 +14,7 @@
     "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Fabric-Capacity",
     "nonComplianceMessages": [
       {
-        "message": "Deploying a Microsoft Fabric Capacity in the Landing Zones is managed by the Data Foundations team. See TechDocs for more information: https://developer.gov.bc.ca/docs/default/component/public-cloud-techdocs/azure/azure-services/external-fabric/"
+        "message": "Provisioning a Fabric Capacity is restricted to authorized subscriptions in the Landing Zone. Please see Tech Docs for more information on how to request a new Fabric capacity: https://developer.gov.bc.ca/docs/default/component/public-cloud-techdocs/azure/azure-services/external-fabric/"
       }
     ],
     "scope": "${current_scope_resource_id}",


### PR DESCRIPTION
This pull request makes a small update to the non-compliance message in the policy assignment for denying the creation of Microsoft Fabric Capacity. The new message clarifies the restriction and provides updated guidance for requesting new capacity.

* Updated the `nonComplianceMessages` text in `policy_assignment_deny_creating_fabric_capacity.json` to clarify that provisioning Fabric Capacity is restricted to authorized subscriptions and included a link to the relevant Tech Docs for requesting new capacity.