### PR TITLE
Add VNet Flow Logs for DNS VNets

### DIFF
--- a/azure_private_dns/virtual_network/README.md
+++ b/azure_private_dns/virtual_network/README.md
@@ -7,7 +7,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.10 |
-| <a name="requirement_azureipam"></a> [azureipam](#requirement\_azureipam) | ~> 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.76 |
 
 ## Providers
@@ -20,7 +19,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_network_flow_logs"></a> [network\_flow\_logs](#module\_network\_flow\_logs) | Azure/avm-res-network-networkwatcher/azurerm | 0.3.0 |
+| <a name="module_network_flow_logs"></a> [network\_flow\_logs](#module\_network\_flow\_logs) | Azure/avm-res-network-networkwatcher/azurerm | 0.3.2 |
 
 ## Resources
 

--- a/azure_private_dns/virtual_network/README.md
+++ b/azure_private_dns/virtual_network/README.md
@@ -18,7 +18,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_network_flow_logs"></a> [network\_flow\_logs](#module\_network\_flow\_logs) | Azure/avm-res-network-networkwatcher/azurerm | 0.3.0 |
 
 ## Resources
 
@@ -41,11 +43,16 @@ No modules.
 | <a name="input_firewall_private_ip_address"></a> [firewall\_private\_ip\_address](#input\_firewall\_private\_ip\_address) | (Required) Private IP address of the Azure Firewall to connect to. | `list(string)` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Azure region to deploy to. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_network_manager_ipam_pool_id"></a> [network\_manager\_ipam\_pool\_id](#input\_network\_manager\_ipam\_pool\_id) | IPAM Pool id | `string` | n/a | yes |
+| <a name="input_primary_location"></a> [primary\_location](#input\_primary\_location) | The primary location for resources | `string` | `"canadacentral"` | no |
 | <a name="input_private_dns_resolver_virtual_network_name"></a> [private\_dns\_resolver\_virtual\_network\_name](#input\_private\_dns\_resolver\_virtual\_network\_name) | (Required) Name of the Virtual Network to deploy the Private DNS Resolver into. | `string` | n/a | yes |
 | <a name="input_private_dns_resource_group_name"></a> [private\_dns\_resource\_group\_name](#input\_private\_dns\_resource\_group\_name) | (Required) Name of the Resource Group to deploy the Private DNS Resolver into. | `string` | n/a | yes |
+| <a name="input_secondary_location"></a> [secondary\_location](#input\_secondary\_location) | The secondary location for resources | `string` | `"canadaeast"` | no |
 | <a name="input_subscription_id_connectivity"></a> [subscription\_id\_connectivity](#input\_subscription\_id\_connectivity) | (Required) Subscription ID to use for "connectivity" resources. | `string` | n/a | yes |
 | <a name="input_virtual_wan_hub_name"></a> [virtual\_wan\_hub\_name](#input\_virtual\_wan\_hub\_name) | (Required) Name of the Virtual WAN Hub to connect to. | `string` | n/a | yes |
 | <a name="input_virtual_wan_hub_resource_group"></a> [virtual\_wan\_hub\_resource\_group](#input\_virtual\_wan\_hub\_resource\_group) | (Required) Resource Group of the Virtual WAN hub. | `string` | n/a | yes |
+| <a name="input_vnet_flow_logs_storage_account_id"></a> [vnet\_flow\_logs\_storage\_account\_id](#input\_vnet\_flow\_logs\_storage\_account\_id) | Storage account ID for storing VNet flow logs | `string` | n/a | yes |
+| <a name="input_workspace_id"></a> [workspace\_id](#input\_workspace\_id) | Log Analytics workspace ID for traffic analytics | `string` | n/a | yes |
+| <a name="input_workspace_resource_id"></a> [workspace\_resource\_id](#input\_workspace\_resource\_id) | Log Analytics workspace resource ID for traffic analytics | `string` | n/a | yes |
 
 ## Outputs
 

--- a/azure_private_dns/virtual_network/README.md
+++ b/azure_private_dns/virtual_network/README.md
@@ -42,10 +42,10 @@
 | <a name="input_firewall_private_ip_address"></a> [firewall\_private\_ip\_address](#input\_firewall\_private\_ip\_address) | (Required) Private IP address of the Azure Firewall to connect to. | `list(string)` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Azure region to deploy to. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_network_manager_ipam_pool_id"></a> [network\_manager\_ipam\_pool\_id](#input\_network\_manager\_ipam\_pool\_id) | IPAM Pool id | `string` | n/a | yes |
-| <a name="input_primary_location"></a> [primary\_location](#input\_primary\_location) | The primary location for resources | `string` | `"canadacentral"` | no |
+| <a name="input_primary_location"></a> [primary\_location](#input\_primary\_location) | Primary Azure region short name for Network Watcher and traffic analytics resources. Must align with location. | `string` | `"canadacentral"` | no |
 | <a name="input_private_dns_resolver_virtual_network_name"></a> [private\_dns\_resolver\_virtual\_network\_name](#input\_private\_dns\_resolver\_virtual\_network\_name) | (Required) Name of the Virtual Network to deploy the Private DNS Resolver into. | `string` | n/a | yes |
 | <a name="input_private_dns_resource_group_name"></a> [private\_dns\_resource\_group\_name](#input\_private\_dns\_resource\_group\_name) | (Required) Name of the Resource Group to deploy the Private DNS Resolver into. | `string` | n/a | yes |
-| <a name="input_secondary_location"></a> [secondary\_location](#input\_secondary\_location) | The secondary location for resources | `string` | `"canadaeast"` | no |
+| <a name="input_secondary_location"></a> [secondary\_location](#input\_secondary\_location) | Secondary Azure region short name reserved for future region expansion. | `string` | `"canadaeast"` | no |
 | <a name="input_subscription_id_connectivity"></a> [subscription\_id\_connectivity](#input\_subscription\_id\_connectivity) | (Required) Subscription ID to use for "connectivity" resources. | `string` | n/a | yes |
 | <a name="input_virtual_wan_hub_name"></a> [virtual\_wan\_hub\_name](#input\_virtual\_wan\_hub\_name) | (Required) Name of the Virtual WAN Hub to connect to. | `string` | n/a | yes |
 | <a name="input_virtual_wan_hub_resource_group"></a> [virtual\_wan\_hub\_resource\_group](#input\_virtual\_wan\_hub\_resource\_group) | (Required) Resource Group of the Virtual WAN hub. | `string` | n/a | yes |

--- a/azure_private_dns/virtual_network/flow_logs.tf
+++ b/azure_private_dns/virtual_network/flow_logs.tf
@@ -4,17 +4,17 @@ module "network_flow_logs" {
   source  = "Azure/avm-res-network-networkwatcher/azurerm"
   version = "0.3.2"
 
-  location             = var.primary_location
-  network_watcher_id   = format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkWatchers/NetworkWatcher_%s", var.subscription_id_connectivity, local.NetworkWatcherRGName, lower(var.primary_location))
-  network_watcher_name = "NetworkWatcher_${lower(var.primary_location)}"
-  resource_group_name  = local.NetworkWatcherRGName
+  location             = local.network_watcher_location
+  network_watcher_id   = format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkWatchers/NetworkWatcher_%s", var.subscription_id_connectivity, local.network_watcher_resource_group_name, local.network_watcher_location)
+  network_watcher_name = "NetworkWatcher_${local.network_watcher_location}"
+  resource_group_name  = local.network_watcher_resource_group_name
   enable_telemetry     = false
   flow_logs = {
     (azurerm_virtual_network.this.name) = {
       enabled              = true
       name                 = "${azurerm_virtual_network.this.name}-network-flowlog" # The name can be up to 80 characters long
       target_resource_id   = azurerm_virtual_network.this.id
-      network_watcher_name = format("NetworkWatcher_%s", lower(var.primary_location))
+      network_watcher_name = format("NetworkWatcher_%s", local.network_watcher_location)
       storage_account_id   = var.vnet_flow_logs_storage_account_id
       version              = 2
 
@@ -27,7 +27,7 @@ module "network_flow_logs" {
         enabled               = true
         interval_in_minutes   = 60
         workspace_id          = var.workspace_id
-        workspace_region      = var.primary_location
+        workspace_region      = local.network_watcher_location
         workspace_resource_id = var.workspace_resource_id
       }
     }

--- a/azure_private_dns/virtual_network/flow_logs.tf
+++ b/azure_private_dns/virtual_network/flow_logs.tf
@@ -1,6 +1,6 @@
 module "network_flow_logs" {
   source  = "Azure/avm-res-network-networkwatcher/azurerm"
-  version = "0.3.0"
+  version = "0.3.2"
 
   location             = var.primary_location
   network_watcher_id   = format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkWatchers/NetworkWatcher_%s", var.subscription_id_connectivity, local.NetworkWatcherRGName, lower(var.primary_location))

--- a/azure_private_dns/virtual_network/flow_logs.tf
+++ b/azure_private_dns/virtual_network/flow_logs.tf
@@ -1,4 +1,6 @@
 module "network_flow_logs" {
+  # IMPORTANT: Traffic Analytics does not support Management Group permissions inheritance! Therefore, direct assignment on the target Subscription is required.
+  # See: https://learn.microsoft.com/en-us/azure/network-watcher/secure-network-watcher#identity-and-access-management and https://learn.microsoft.com/en-us/azure/network-watcher/required-rbac-permissions#traffic-analytics
   source  = "Azure/avm-res-network-networkwatcher/azurerm"
   version = "0.3.2"
 

--- a/azure_private_dns/virtual_network/flow_logs.tf
+++ b/azure_private_dns/virtual_network/flow_logs.tf
@@ -1,0 +1,33 @@
+module "network_flow_logs" {
+  source  = "Azure/avm-res-network-networkwatcher/azurerm"
+  version = "0.3.0"
+
+  location             = var.primary_location
+  network_watcher_id   = format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkWatchers/NetworkWatcher_%s", var.subscription_id_connectivity, local.NetworkWatcherRGName, lower(var.primary_location))
+  network_watcher_name = "NetworkWatcher_${lower(var.primary_location)}"
+  resource_group_name  = local.NetworkWatcherRGName
+  enable_telemetry     = false
+  flow_logs = {
+    (azurerm_virtual_network.this.name) = {
+      enabled              = true
+      name                 = "${azurerm_virtual_network.this.name}-network-flowlog" # The name can be up to 80 characters long
+      target_resource_id   = azurerm_virtual_network.this.id
+      network_watcher_name = format("NetworkWatcher_%s", lower(var.primary_location))
+      storage_account_id   = var.vnet_flow_logs_storage_account_id
+      version              = 2
+
+      retention_policy = {
+        days    = 90
+        enabled = true
+      }
+
+      traffic_analytics = {
+        enabled               = true
+        interval_in_minutes   = 60
+        workspace_id          = var.workspace_id
+        workspace_region      = var.primary_location
+        workspace_resource_id = var.workspace_resource_id
+      }
+    }
+  }
+}

--- a/azure_private_dns/virtual_network/locals.tf
+++ b/azure_private_dns/virtual_network/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  api_url = var.environment == "FORGE" ? "https://ipam-forge.azurewebsites.net" : "https://ipam-live.azurewebsites.net"
+  api_url              = var.environment == "FORGE" ? "https://ipam-forge.azurewebsites.net" : "https://ipam-live.azurewebsites.net"
+  NetworkWatcherRGName = "NetworkWatcherRG"
 }

--- a/azure_private_dns/virtual_network/locals.tf
+++ b/azure_private_dns/virtual_network/locals.tf
@@ -1,4 +1,3 @@
 locals {
-  api_url              = var.environment == "FORGE" ? "https://ipam-forge.azurewebsites.net" : "https://ipam-live.azurewebsites.net"
   NetworkWatcherRGName = "NetworkWatcherRG"
 }

--- a/azure_private_dns/virtual_network/locals.tf
+++ b/azure_private_dns/virtual_network/locals.tf
@@ -1,3 +1,5 @@
 locals {
-  NetworkWatcherRGName = "NetworkWatcherRG"
+  environment_suffix                  = lower(var.environment)
+  network_watcher_location            = var.primary_location
+  network_watcher_resource_group_name = "NetworkWatcherRG"
 }

--- a/azure_private_dns/virtual_network/provider.tf
+++ b/azure_private_dns/virtual_network/provider.tf
@@ -11,11 +11,6 @@ terraform {
       source  = "azure/azapi"
       version = "~> 2.10"
     }
-
-    azureipam = {
-      source  = "XtratusCloud/azureipam"
-      version = "~> 2.0"
-    }
   }
 }
 

--- a/azure_private_dns/virtual_network/variables.tf
+++ b/azure_private_dns/virtual_network/variables.tf
@@ -23,6 +23,18 @@ variable "location" {
   }
 }
 
+variable "primary_location" {
+  description = "The primary location for resources"
+  type        = string
+  default     = "canadacentral"
+}
+
+variable "secondary_location" {
+  description = "The secondary location for resources"
+  type        = string
+  default     = "canadaeast"
+}
+
 variable "private_dns_resource_group_name" {
   description = "(Required) Name of the Resource Group to deploy the Private DNS Resolver into."
   type        = string
@@ -51,4 +63,20 @@ variable "private_dns_resolver_virtual_network_name" {
 variable "network_manager_ipam_pool_id" {
   type        = string
   description = "IPAM Pool id"
+}
+
+
+variable "vnet_flow_logs_storage_account_id" {
+  description = "Storage account ID for storing VNet flow logs"
+  type        = string
+}
+
+variable "workspace_id" {
+  description = "Log Analytics workspace ID for traffic analytics"
+  type        = string
+}
+
+variable "workspace_resource_id" {
+  description = "Log Analytics workspace resource ID for traffic analytics"
+  type        = string
 }

--- a/azure_private_dns/virtual_network/variables.tf
+++ b/azure_private_dns/virtual_network/variables.tf
@@ -24,15 +24,30 @@ variable "location" {
 }
 
 variable "primary_location" {
-  description = "The primary location for resources"
+  description = "Primary Azure region short name for Network Watcher and traffic analytics resources. Must align with location."
   type        = string
   default     = "canadacentral"
+
+  validation {
+    condition     = contains(["canadacentral", "canadaeast"], var.primary_location)
+    error_message = "ERROR: Valid values for primary_location are: \"canadaeast\", \"canadacentral\"."
+  }
+
+  validation {
+    condition     = var.primary_location == replace(lower(var.location), " ", "")
+    error_message = "ERROR: primary_location must match location using the Azure region short name without spaces."
+  }
 }
 
 variable "secondary_location" {
-  description = "The secondary location for resources"
+  description = "Secondary Azure region short name reserved for future region expansion."
   type        = string
   default     = "canadaeast"
+
+  validation {
+    condition     = contains(["canadacentral", "canadaeast"], var.secondary_location)
+    error_message = "ERROR: Valid values for secondary_location are: \"canadaeast\", \"canadacentral\"."
+  }
 }
 
 variable "private_dns_resource_group_name" {


### PR DESCRIPTION
This pull request introduces network flow logs support for the virtual network module, adds new input variables for configuring flow logging and analytics, and removes the unused `azureipam` provider. The main changes are the integration of the `network_flow_logs` module, updates to documentation, and the addition of variables needed for flow log configuration.

**Network Flow Logs Integration**
- Added a new `network_flow_logs` module (`Azure/avm-res-network-networkwatcher/azurerm` version 0.3.2) to enable and configure flow logs and traffic analytics for the virtual network, including storage and analytics workspace integration.

**Provider and Local Changes**
- Removed the unused `azureipam` provider from both `provider.tf` and the documentation, simplifying dependencies. [[1]](diffhunk://#diff-81b781a30ebf443da9774b5f9ccff2aadeb4b0443fad1012e0e72dd6b02a09fcL14-L18) [[2]](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3L10)
- Added a new local variable `NetworkWatcherRGName` to `locals.tf` for consistent resource group naming.

**Input Variables**
- Introduced new variables: `primary_location`, `secondary_location`, `vnet_flow_logs_storage_account_id`, `workspace_id`, and `workspace_resource_id` to support flow log and analytics configuration. [[1]](diffhunk://#diff-0a59d9852acf70890d7542d115f4586bd676a4a84d6f4ccd33b7002c1c4b28afR26-R37) [[2]](diffhunk://#diff-0a59d9852acf70890d7542d115f4586bd676a4a84d6f4ccd33b7002c1c4b28afR67-R82)

**Documentation Updates**
- Updated the `README.md` to reflect the new module, input variables, and removed references to the deleted provider. [[1]](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3L21-R22) [[2]](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3R45-R54) [[3]](diffhunk://#diff-0ed1ca70a477d9a574afad6221f155b066f6a8923c65783cfeee9e1efb70aea3L10)