### PR TITLE
AZR-207 - Allow Public IPs on Function App slots

### DIFF
--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_public_paas_endpoints.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_deny_public_paas_endpoints.json
@@ -46,6 +46,9 @@
       "FunctionPublicIpDenyEffect": {
         "value": "Disabled"
       },
+      "FunctionAppSlotPublicIpDenyEffect": {
+        "value": "Disabled"
+      },
       "KeyVaultPublicIpDenyEffect": {
         "value": "Deny"
       },


### PR DESCRIPTION
Currently, Azure Function Apps are permitted to have Public IPs in the ALZ, but Function App slots with public endpoints are blocked.  This change sets the slot policy parameter to 'Disabled' to allow users to employ slots on public-facing Function Apps.