### PR TITLE
Added policy definition README for known issues

### DIFF
--- a/caf_cccs_medium/modules/core/lib/policy_definitions/README.md
+++ b/caf_cccs_medium/modules/core/lib/policy_definitions/README.md
@@ -1,0 +1,17 @@
+# Known Issues
+
+The following policy definitions have known issues that may affect their functionality or behavior. Please review the details below before using these policies in your environment.
+
+## Deny Creating Azure AI Search Services
+
+This custom policy definition, although being a part of the custom policy assignment (`Deny deployment of selected Azure AI Services`), throws a different error message in the Azure portal when a user attempts to create an Azure AI Search Service. The error message displayed is:
+
+```text
+The resource deployment was blocked because it does not comply with the Azure Policy requiring customer-managed key (CMK) encryption. To proceed, enable CMK encryption in the Encryption tab.
+```
+
+This is despite the policy definition not having a custom non-compliance message configured, and the policy assignment itself having a generic non-compliance message.
+
+According to Copilot:
+
+> Most likely explanation: The CMK wording is a generic/misleading UX message from the Search deployment flow for policy-denied creates, not the actual deny rule that fired in this request.


### PR DESCRIPTION
This pull request adds documentation about known issues affecting policy definitions in the `caf_cccs_medium/modules/core/lib/policy_definitions/README.md` file. The main addition is a section describing an issue with the "Deny Creating Azure AI Search Services" policy, including details about misleading error messages in the Azure portal.

Documentation updates:

* Added a "Known Issues" section to the `README.md` for policy definitions, documenting a specific issue where the "Deny Creating Azure AI Search Services" policy displays a misleading CMK-related error message in the Azure portal, despite no custom non-compliance message being set.