### PR TITLE
Add VWAN routing modules and VPN routing ignore_changes

### DIFF
--- a/azure_vpn/vpn_gateway_connection/README.md
+++ b/azure_vpn/vpn_gateway_connection/README.md
@@ -4,14 +4,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.76 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.76 |
 
 ## Modules
@@ -21,14 +21,14 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_vpn_gateway_connection.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/vpn_gateway_connection) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_subscription_id_connectivity"></a> [subscription\_id\_connectivity](#input\_subscription\_id\_connectivity) | Subscription ID to use for "connectivity" resources. | `string` | n/a | yes |
 | <a name="input_subscription_id_management"></a> [subscription\_id\_management](#input\_subscription\_id\_management) | Subscription ID to use for "management" resources. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource. | `map(string)` | `null` | no |
@@ -37,7 +37,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpn_gateway_connection_ids"></a> [vpn\_gateway\_connection\_ids](#output\_vpn\_gateway\_connection\_ids) | A map of VPN Gateway Connection IDs keyed by their names. |
 | <a name="output_vpn_gateway_connection_internet_security_enabled"></a> [vpn\_gateway\_connection\_internet\_security\_enabled](#output\_vpn\_gateway\_connection\_internet\_security\_enabled) | A map indicating if Internet Security is enabled for each VPN Gateway Connection, keyed by their names. |
 | <a name="output_vpn_gateway_connection_names"></a> [vpn\_gateway\_connection\_names](#output\_vpn\_gateway\_connection\_names) | A list of VPN Gateway Connection names. |

--- a/azure_vpn/vpn_gateway_connection/vpn_gateway_connection.tf
+++ b/azure_vpn/vpn_gateway_connection/vpn_gateway_connection.tf
@@ -81,4 +81,11 @@ resource "azurerm_vpn_gateway_connection" "this" {
       remote_address_ranges = traffic_selector_policy.value.remote_address_ranges
     }
   }
+
+  # Branch connection routing (route maps / hub route tables) is owned by
+  # azure_vwan/routing via azapi_update_resource. Ignore drift here so VPN
+  # stack applies do not clear or fight that configuration.
+  lifecycle {
+    ignore_changes = [routing]
+  }
 }

--- a/azure_vwan/README.md
+++ b/azure_vwan/README.md
@@ -1,25 +1,11 @@
-<!-- BEGIN_TF_DOCS -->
-## Requirements
+# azure_vwan
 
-No requirements.
+Shared modules for Azure Virtual WAN concerns that sit outside CAF:
 
-## Providers
+| Module | Purpose |
+|--------|---------|
+| `routing_intent_and_policies` | Hub default route table / routing-intent related routes |
+| `route_maps` | Virtual hub route maps (filter / summarize BGP advertisements) |
 
-No providers.
-
-## Modules
-
-No modules.
-
-## Resources
-
-No resources.
-
-## Inputs
-
-No inputs.
-
-## Outputs
-
-No outputs.
-<!-- END_TF_DOCS -->
+Callers: `azure-lz-core-forge` / `azure-lz-core-live` under `azure_vwan/`.
+Route-map **attachment** to VPN/ExR connections is owned by the env `azure_vwan/routing` stack (azapi), not this module.

--- a/azure_vwan/README.md
+++ b/azure_vwan/README.md
@@ -11,3 +11,29 @@ Shared modules for Azure Virtual WAN concerns that sit outside CAF:
 Callers: `azure-lz-core-forge` / `azure-lz-core-live` under `azure_vwan/`.
 
 Prefer `routing` for the standard on-prem outbound filter. Use `route_maps` only when you need custom map rules without the connection-attachment opinion.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/azure_vwan/README.md
+++ b/azure_vwan/README.md
@@ -9,3 +9,29 @@ Shared modules for Azure Virtual WAN concerns that sit outside CAF:
 
 Callers: `azure-lz-core-forge` / `azure-lz-core-live` under `azure_vwan/`.
 Route-map **attachment** to VPN/ExR connections is owned by the env `azure_vwan/routing` stack (azapi), not this module.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/azure_vwan/README.md
+++ b/azure_vwan/README.md
@@ -5,33 +5,9 @@ Shared modules for Azure Virtual WAN concerns that sit outside CAF:
 | Module | Purpose |
 |--------|---------|
 | `routing_intent_and_policies` | Hub default route table / routing-intent related routes |
-| `route_maps` | Virtual hub route maps (filter / summarize BGP advertisements) |
+| `route_maps` | Low-level Virtual Hub route maps (filter / summarize BGP advertisements) |
+| `routing` | Opinionated outbound ASN-drop map + VPN/ExR `routingConfiguration` attachments |
 
 Callers: `azure-lz-core-forge` / `azure-lz-core-live` under `azure_vwan/`.
-Route-map **attachment** to VPN/ExR connections is owned by the env `azure_vwan/routing` stack (azapi), not this module.
 
-<!-- BEGIN_TF_DOCS -->
-## Requirements
-
-No requirements.
-
-## Providers
-
-No providers.
-
-## Modules
-
-No modules.
-
-## Resources
-
-No resources.
-
-## Inputs
-
-No inputs.
-
-## Outputs
-
-No outputs.
-<!-- END_TF_DOCS -->
+Prefer `routing` for the standard on-prem outbound filter. Use `route_maps` only when you need custom map rules without the connection-attachment opinion.

--- a/azure_vwan/route_maps/README.md
+++ b/azure_vwan/route_maps/README.md
@@ -1,0 +1,91 @@
+# azure_vwan/route_maps
+
+Manages Azure Virtual WAN hub route maps (`azurerm_route_map`).
+
+Use this to control routes advertised to or from VPN and ExpressRoute connections (for example, drop on-premises ASNs outbound, or summarize Azure prefixes).
+
+Attachment to connections is **not** handled here. Pass the output route map ID into:
+
+- `azure_vpn/vpn_gateway_connection` → `routing.outbound_route_map_id` / `inbound_route_map_id`
+- `azure_express_route/express_route_connection` → `routing.outbound_route_map_id` / `inbound_route_map_id`
+
+## Example
+
+```hcl
+module "vwan_route_maps" {
+  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_vwan/route_maps?ref=vX.Y.Z"
+
+  subscription_id_connectivity = var.subscription_id_connectivity
+  virtual_hub_id               = data.azurerm_virtual_hub.this.id
+
+  route_maps = {
+    outbound_to_onprem = {
+      name = "outbound-to-onprem"
+      rules = [
+        {
+          name                 = "drop-onprem-asn"
+          next_step_if_matched = "Terminate"
+          match_criteria = [
+            {
+              match_condition = "Contains"
+              as_path         = ["64551"]
+            }
+          ]
+          actions = [
+            {
+              type = "Drop"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Import
+
+```shell
+terraform import 'module.vwan_route_maps.azurerm_route_map.this["outbound_to_onprem"]' \
+  /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualHubs/<hub>/routeMaps/outbound-to-onprem
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.76 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.76 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_route_map.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_map) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_route_maps"></a> [route\_maps](#input\_route\_maps) | Map of Virtual Hub route maps to manage.<br/>Key is a stable Terraform identifier; each value.name is the Azure route map name.<br/>Rules are applied in list order. | <pre>map(object({<br/>    name = string<br/>    rules = list(object({<br/>      name                 = string<br/>      next_step_if_matched = optional(string, "Terminate")<br/>      match_criteria = optional(list(object({<br/>        match_condition = string<br/>        as_path         = optional(list(string), [])<br/>        community       = optional(list(string), [])<br/>        route_prefix    = optional(list(string), [])<br/>      })), [])<br/>      actions = optional(list(object({<br/>        type         = string<br/>        as_path      = optional(list(string), [])<br/>        community    = optional(list(string), [])<br/>        route_prefix = optional(list(string), [])<br/>      })), [])<br/>    }))<br/>  }))</pre> | n/a | yes |
+| <a name="input_subscription_id_connectivity"></a> [subscription\_id\_connectivity](#input\_subscription\_id\_connectivity) | Subscription ID to use for "connectivity" resources. | `string` | n/a | yes |
+| <a name="input_virtual_hub_id"></a> [virtual\_hub\_id](#input\_virtual\_hub\_id) | Resource ID of the Virtual Hub that owns the route maps. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_route_map_ids"></a> [route\_map\_ids](#output\_route\_map\_ids) | Map of route map Terraform keys to Azure resource IDs. |
+| <a name="output_route_maps"></a> [route\_maps](#output\_route\_maps) | Full azurerm\_route\_map resources keyed by Terraform map key. |
+<!-- END_TF_DOCS -->

--- a/azure_vwan/route_maps/main.tf
+++ b/azure_vwan/route_maps/main.tf
@@ -1,0 +1,44 @@
+resource "azurerm_route_map" "this" {
+  for_each = var.route_maps
+
+  name           = each.value.name
+  virtual_hub_id = var.virtual_hub_id
+
+  dynamic "rule" {
+    for_each = each.value.rules
+
+    content {
+      name                 = rule.value.name
+      next_step_if_matched = rule.value.next_step_if_matched
+
+      dynamic "match_criterion" {
+        for_each = rule.value.match_criteria
+
+        content {
+          match_condition = match_criterion.value.match_condition
+          as_path         = length(match_criterion.value.as_path) > 0 ? match_criterion.value.as_path : null
+          community       = length(match_criterion.value.community) > 0 ? match_criterion.value.community : null
+          route_prefix    = length(match_criterion.value.route_prefix) > 0 ? match_criterion.value.route_prefix : null
+        }
+      }
+
+      dynamic "action" {
+        for_each = rule.value.actions
+
+        content {
+          type = action.value.type
+
+          dynamic "parameter" {
+            for_each = action.value.type == "Drop" ? [] : [action.value]
+
+            content {
+              as_path      = length(parameter.value.as_path) > 0 ? parameter.value.as_path : null
+              community    = length(parameter.value.community) > 0 ? parameter.value.community : null
+              route_prefix = length(parameter.value.route_prefix) > 0 ? parameter.value.route_prefix : null
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/azure_vwan/route_maps/outputs.tf
+++ b/azure_vwan/route_maps/outputs.tf
@@ -1,0 +1,9 @@
+output "route_map_ids" {
+  description = "Map of route map Terraform keys to Azure resource IDs."
+  value       = { for key, route_map in azurerm_route_map.this : key => route_map.id }
+}
+
+output "route_maps" {
+  description = "Full azurerm_route_map resources keyed by Terraform map key."
+  value       = azurerm_route_map.this
+}

--- a/azure_vwan/route_maps/provider.tf
+++ b/azure_vwan/route_maps/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">=1.9.0, < 2.0.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.76"
+    }
+  }
+}
+
+# No provider block: callers pass azurerm via `providers = { azurerm = azurerm.connectivity }`.

--- a/azure_vwan/route_maps/variables-route_maps.tf
+++ b/azure_vwan/route_maps/variables-route_maps.tf
@@ -1,0 +1,31 @@
+variable "virtual_hub_id" {
+  description = "Resource ID of the Virtual Hub that owns the route maps."
+  type        = string
+}
+
+variable "route_maps" {
+  description = <<-EOT
+    Map of Virtual Hub route maps to manage.
+    Key is a stable Terraform identifier; each value.name is the Azure route map name.
+    Rules are applied in list order.
+  EOT
+  type = map(object({
+    name = string
+    rules = list(object({
+      name                 = string
+      next_step_if_matched = optional(string, "Terminate")
+      match_criteria = optional(list(object({
+        match_condition = string
+        as_path         = optional(list(string), [])
+        community       = optional(list(string), [])
+        route_prefix    = optional(list(string), [])
+      })), [])
+      actions = optional(list(object({
+        type         = string
+        as_path      = optional(list(string), [])
+        community    = optional(list(string), [])
+        route_prefix = optional(list(string), [])
+      })), [])
+    }))
+  }))
+}

--- a/azure_vwan/route_maps/variables.common.tf
+++ b/azure_vwan/route_maps/variables.common.tf
@@ -1,0 +1,4 @@
+variable "subscription_id_connectivity" {
+  type        = string
+  description = "Subscription ID to use for \"connectivity\" resources."
+}

--- a/azure_vwan/routing/README.md
+++ b/azure_vwan/routing/README.md
@@ -1,0 +1,100 @@
+# azure_vwan/routing
+
+Opinionated Virtual WAN branch-routing module for FORGE/LIVE:
+
+1. Creates an outbound hub route map that **Drops** routes whose AS-Path Contains the configured on-prem BGP ASN(s).
+2. Attaches that map (plus default associate / none propagate) to existing VPN and ExpressRoute connections via `azapi_update_resource`.
+
+Connection *resources* stay in their existing stacks. This module only owns route maps and connection `routingConfiguration`.
+
+## Usage
+
+```hcl
+module "vwan_routing" {
+  source = "git::https://github.com/bcgov/azure-lz-terraform-modules.git//azure_vwan/routing?ref=<version>"
+
+  providers = {
+    azurerm = azurerm.connectivity
+    azapi   = azapi
+  }
+
+  subscription_id_connectivity    = var.subscription_id_connectivity
+  virtual_hub_id                  = data.azurerm_virtual_hub.this.id
+  virtual_hub_resource_group_name = var.virtual_hub_resource_group_name
+  onprem_bgp_asns                 = ["64551"]
+
+  vpn_connection_routing = {
+    kamloops = {
+      vpn_gateway_name    = "..."
+      vpn_connection_name = "..."
+    }
+  }
+
+  express_route_connection_routing = {
+    canadacentral = {
+      express_route_gateway_name    = "..."
+      express_route_connection_name = "..."
+    }
+  }
+}
+```
+
+## Notes
+
+- Removing `azapi_update_resource` from config does **not** clear Azure `routingConfiguration`.
+- Pair with `azure_vpn/vpn_gateway_connection` `lifecycle.ignore_changes = [routing]` so VPN stacks do not fight this module.
+- Low-level custom maps (without the ASN-drop opinion) remain available via `azure_vwan/route_maps`.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.10 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.76 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | ~> 2.10 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_route_maps"></a> [route\_maps](#module\_route\_maps) | ../route_maps | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azapi_update_resource.express_route_connection_routing](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) | resource |
+| [azapi_update_resource.vpn_connection_routing](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_associated_route_table_id"></a> [associated\_route\_table\_id](#input\_associated\_route\_table\_id) | Hub route table ID to associate on branch connections. Defaults to the hub defaultRouteTable. | `string` | `null` | no |
+| <a name="input_express_route_connection_routing"></a> [express\_route\_connection\_routing](#input\_express\_route\_connection\_routing) | ExpressRoute gateway connections that should receive the outbound route map via routingConfiguration. | <pre>map(object({<br/>    express_route_gateway_name    = string<br/>    express_route_connection_name = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_onprem_bgp_asns"></a> [onprem\_bgp\_asns](#input\_onprem\_bgp\_asns) | On-premises BGP ASNs to drop from outbound advertisements (AS-Path Contains). | `list(string)` | n/a | yes |
+| <a name="input_outbound_route_map_key"></a> [outbound\_route\_map\_key](#input\_outbound\_route\_map\_key) | Stable Terraform map key for the outbound route map. | `string` | `"outbound_to_onprem"` | no |
+| <a name="input_outbound_route_map_name"></a> [outbound\_route\_map\_name](#input\_outbound\_route\_map\_name) | Azure name of the outbound route map resource. | `string` | `"outbound-to-onprem"` | no |
+| <a name="input_propagated_route_table_id"></a> [propagated\_route\_table\_id](#input\_propagated\_route\_table\_id) | Hub route table ID to propagate on branch connections. Defaults to the hub noneRouteTable. | `string` | `null` | no |
+| <a name="input_propagated_route_table_labels"></a> [propagated\_route\_table\_labels](#input\_propagated\_route\_table\_labels) | Labels for propagatedRouteTables on branch connections. | `list(string)` | <pre>[<br/>  "none"<br/>]</pre> | no |
+| <a name="input_subscription_id_connectivity"></a> [subscription\_id\_connectivity](#input\_subscription\_id\_connectivity) | Subscription ID for connectivity resources (used to build gateway parent IDs). | `string` | n/a | yes |
+| <a name="input_virtual_hub_id"></a> [virtual\_hub\_id](#input\_virtual\_hub\_id) | Resource ID of the Virtual Hub. | `string` | n/a | yes |
+| <a name="input_virtual_hub_resource_group_name"></a> [virtual\_hub\_resource\_group\_name](#input\_virtual\_hub\_resource\_group\_name) | Resource group name of the Virtual Hub / VPN / ExpressRoute gateways. | `string` | n/a | yes |
+| <a name="input_vpn_connection_routing"></a> [vpn\_connection\_routing](#input\_vpn\_connection\_routing) | VPN gateway connections that should receive the outbound route map via routingConfiguration. | <pre>map(object({<br/>    vpn_gateway_name    = string<br/>    vpn_connection_name = string<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_express_route_connection_routing_ids"></a> [express\_route\_connection\_routing\_ids](#output\_express\_route\_connection\_routing\_ids) | ExpressRoute connections whose routingConfiguration is managed by this module. |
+| <a name="output_outbound_route_map_id"></a> [outbound\_route\_map\_id](#output\_outbound\_route\_map\_id) | Resource ID of the outbound-to-onprem route map. |
+| <a name="output_route_map_ids"></a> [route\_map\_ids](#output\_route\_map\_ids) | Map of route map keys to Azure resource IDs. |
+| <a name="output_vpn_connection_routing_ids"></a> [vpn\_connection\_routing\_ids](#output\_vpn\_connection\_routing\_ids) | VPN connections whose routingConfiguration is managed by this module. |
+<!-- END_TF_DOCS -->

--- a/azure_vwan/routing/locals.tf
+++ b/azure_vwan/routing/locals.tf
@@ -1,0 +1,54 @@
+locals {
+  associated_route_table_id = coalesce(
+    var.associated_route_table_id,
+    "${var.virtual_hub_id}/hubRouteTables/defaultRouteTable",
+  )
+
+  propagated_route_table_id = coalesce(
+    var.propagated_route_table_id,
+    "${var.virtual_hub_id}/hubRouteTables/noneRouteTable",
+  )
+
+  route_maps = {
+    (var.outbound_route_map_key) = {
+      name = var.outbound_route_map_name
+      rules = [
+        {
+          name                 = "drop-onprem-asn"
+          next_step_if_matched = "Terminate"
+          match_criteria = [
+            {
+              match_condition = "Contains"
+              as_path         = var.onprem_bgp_asns
+            }
+          ]
+          actions = [
+            {
+              type = "Drop"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  outbound_route_map_id = module.route_maps.route_map_ids[var.outbound_route_map_key]
+
+  # ARM routingConfiguration body shared by VPN and ExpressRoute connections.
+  connection_routing = {
+    associatedRouteTable = {
+      id = local.associated_route_table_id
+    }
+    propagatedRouteTables = {
+      labels = var.propagated_route_table_labels
+      ids = [
+        {
+          id = local.propagated_route_table_id
+        }
+      ]
+    }
+    outboundRouteMap = {
+      id = local.outbound_route_map_id
+    }
+  }
+}

--- a/azure_vwan/routing/main.tf
+++ b/azure_vwan/routing/main.tf
@@ -1,0 +1,52 @@
+module "route_maps" {
+  source = "../route_maps"
+
+  subscription_id_connectivity = var.subscription_id_connectivity
+  virtual_hub_id               = var.virtual_hub_id
+  route_maps                   = local.route_maps
+}
+
+# Patch routingConfiguration on existing VPN connections.
+# azapi_update_resource does not revert properties when removed from config.
+resource "azapi_update_resource" "vpn_connection_routing" {
+  for_each = var.vpn_connection_routing
+
+  type = "Microsoft.Network/vpnGateways/vpnConnections@2024-05-01"
+  name = each.value.vpn_connection_name
+  parent_id = format(
+    "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/vpnGateways/%s",
+    var.subscription_id_connectivity,
+    var.virtual_hub_resource_group_name,
+    each.value.vpn_gateway_name,
+  )
+
+  body = {
+    properties = {
+      routingConfiguration = local.connection_routing
+    }
+  }
+
+  depends_on = [module.route_maps]
+}
+
+# Patch routingConfiguration on existing ExpressRoute connections.
+resource "azapi_update_resource" "express_route_connection_routing" {
+  for_each = var.express_route_connection_routing
+
+  type = "Microsoft.Network/expressRouteGateways/expressRouteConnections@2024-05-01"
+  name = each.value.express_route_connection_name
+  parent_id = format(
+    "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/expressRouteGateways/%s",
+    var.subscription_id_connectivity,
+    var.virtual_hub_resource_group_name,
+    each.value.express_route_gateway_name,
+  )
+
+  body = {
+    properties = {
+      routingConfiguration = local.connection_routing
+    }
+  }
+
+  depends_on = [module.route_maps]
+}

--- a/azure_vwan/routing/outputs.tf
+++ b/azure_vwan/routing/outputs.tf
@@ -1,0 +1,19 @@
+output "route_map_ids" {
+  description = "Map of route map keys to Azure resource IDs."
+  value       = module.route_maps.route_map_ids
+}
+
+output "outbound_route_map_id" {
+  description = "Resource ID of the outbound-to-onprem route map."
+  value       = local.outbound_route_map_id
+}
+
+output "vpn_connection_routing_ids" {
+  description = "VPN connections whose routingConfiguration is managed by this module."
+  value       = { for k, r in azapi_update_resource.vpn_connection_routing : k => r.id }
+}
+
+output "express_route_connection_routing_ids" {
+  description = "ExpressRoute connections whose routingConfiguration is managed by this module."
+  value       = { for k, r in azapi_update_resource.express_route_connection_routing : k => r.id }
+}

--- a/azure_vwan/routing/provider.tf
+++ b/azure_vwan/routing/provider.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">=1.9.0, < 2.0.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.76"
+    }
+
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.10"
+    }
+  }
+}
+
+# No provider blocks: callers pass azurerm (connectivity) and azapi via `providers`.

--- a/azure_vwan/routing/variables.tf
+++ b/azure_vwan/routing/variables.tf
@@ -1,0 +1,67 @@
+variable "subscription_id_connectivity" {
+  type        = string
+  description = "Subscription ID for connectivity resources (used to build gateway parent IDs)."
+}
+
+variable "virtual_hub_id" {
+  description = "Resource ID of the Virtual Hub."
+  type        = string
+}
+
+variable "virtual_hub_resource_group_name" {
+  description = "Resource group name of the Virtual Hub / VPN / ExpressRoute gateways."
+  type        = string
+}
+
+variable "outbound_route_map_key" {
+  description = "Stable Terraform map key for the outbound route map."
+  type        = string
+  default     = "outbound_to_onprem"
+}
+
+variable "outbound_route_map_name" {
+  description = "Azure name of the outbound route map resource."
+  type        = string
+  default     = "outbound-to-onprem"
+}
+
+variable "onprem_bgp_asns" {
+  description = "On-premises BGP ASNs to drop from outbound advertisements (AS-Path Contains)."
+  type        = list(string)
+}
+
+variable "vpn_connection_routing" {
+  description = "VPN gateway connections that should receive the outbound route map via routingConfiguration."
+  type = map(object({
+    vpn_gateway_name    = string
+    vpn_connection_name = string
+  }))
+  default = {}
+}
+
+variable "express_route_connection_routing" {
+  description = "ExpressRoute gateway connections that should receive the outbound route map via routingConfiguration."
+  type = map(object({
+    express_route_gateway_name    = string
+    express_route_connection_name = string
+  }))
+  default = {}
+}
+
+variable "associated_route_table_id" {
+  description = "Hub route table ID to associate on branch connections. Defaults to the hub defaultRouteTable."
+  type        = string
+  default     = null
+}
+
+variable "propagated_route_table_id" {
+  description = "Hub route table ID to propagate on branch connections. Defaults to the hub noneRouteTable."
+  type        = string
+  default     = null
+}
+
+variable "propagated_route_table_labels" {
+  description = "Labels for propagatedRouteTables on branch connections."
+  type        = list(string)
+  default     = ["none"]
+}


### PR DESCRIPTION
## Summary
- Add low-level `azure_vwan/route_maps` shared module for Virtual Hub route maps.
- Add opinionated `azure_vwan/routing` module: ASN-drop outbound map + VPN/ExR `routingConfiguration` attachments via `azapi_update_resource`.
- Add `lifecycle.ignore_changes = [routing]` on `azure_vpn/vpn_gateway_connection` so env routing stacks can own connection routing without VPN stack drift fights.

## Test plan
- [ ] Review module inputs/outputs and Drop-action parameter handling
- [ ] Confirm VPN connection ignore_changes does not affect other connection attributes
- [ ] Consumer PR (`azure-lz-core-forge`) plans successfully against this branch ref
- [ ] After merge, cut a modules release and retarget consumers to the tag