### PR TITLE
Updated AKS Pod CIDR Range

### DIFF
--- a/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
+++ b/caf_cccs_medium/modules/core/lib/policy_assignments/policy_assignment_enforce_aks_cidrs.json
@@ -10,7 +10,8 @@
       "allowedPodCidrRanges": {
         "value": [
           "10.10.0.0/18",
-          "10.10.128.0/18"
+          "10.10.128.0/18",
+          "10.244.0.0/16"
         ]
       },
       "enforceServiceCidr": {


### PR DESCRIPTION
This pull request makes a small update to the `policy_assignment_enforce_aks_cidrs.json` file by adding a new allowed CIDR range for AKS pods.

* Added `"10.244.0.0/16"` to the `allowedPodCidrRanges` list to expand the permitted pod network ranges.