### PR TITLE
Allow DNS Private Resolver inbound NSG rules from any source

### DIFF
--- a/azure_private_dns/virtual_network/README.md
+++ b/azure_private_dns/virtual_network/README.md
@@ -4,7 +4,7 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0, < 2.0.0 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.10 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.76 |
@@ -12,19 +12,19 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.76 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_network_flow_logs"></a> [network\_flow\_logs](#module\_network\_flow\_logs) | Azure/avm-res-network-networkwatcher/azurerm | 0.3.2 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_network_manager_ipam_pool_static_cidr.private_dns_resolver](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_manager_ipam_pool_static_cidr) | resource |
 | [azurerm_network_security_group.inbound_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
 | [azurerm_network_security_group.outbound_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
@@ -37,7 +37,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_environment"></a> [environment](#input\_environment) | (Required) This is either LIVE or FORGE. | `string` | n/a | yes |
 | <a name="input_firewall_private_ip_address"></a> [firewall\_private\_ip\_address](#input\_firewall\_private\_ip\_address) | (Required) Private IP address of the Azure Firewall to connect to. | `list(string)` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Azure region to deploy to. Changing this forces a new resource to be created. | `string` | n/a | yes |
@@ -56,7 +56,7 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_private_dns_resolver_cidr"></a> [private\_dns\_resolver\_cidr](#output\_private\_dns\_resolver\_cidr) | The CIDR block of the Private DNS Resolver |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | The Private DNS Resolver resource group name |
 | <a name="output_virtual_hub_connection"></a> [virtual\_hub\_connection](#output\_virtual\_hub\_connection) | The Private DNS Resolver virtual hub connection object |

--- a/azure_private_dns/virtual_network/vnet.tf
+++ b/azure_private_dns/virtual_network/vnet.tf
@@ -6,28 +6,28 @@ resource "azurerm_network_security_group" "inbound_endpoint" {
   # Per the Microsoft documentation (https://learn.microsoft.com/en-us/azure/architecture/networking/guide/private-link-virtual-wan-dns-single-region-workload#azure-dns-private-resolver)
   # The Network Security Group in the subnet for the DNS Private Resolver's inbound endpoint should only allow DNS traffic from its regional hub to port 53. You should block all other inbound and outbound traffic.
   security_rule {
-    name                       = "AllowUdpFromRegionalHubVNet"
-    description                = "Allow inbound UDP traffic from the regional hub to port 53"
+    name                       = "AllowDNSUdpInbound"
+    description                = "Allow inbound UDP DNS traffic from any source to port 53"
     priority                   = 110
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Udp"
     source_port_range          = "*"
     destination_port_range     = "53"
-    source_address_prefix      = data.azurerm_virtual_hub.vwan_hub.address_prefix
+    source_address_prefix      = "*"
     destination_address_prefix = "VirtualNetwork"
   }
 
   security_rule {
-    name                       = "AllowTcpFromRegionalHubVNet"
-    description                = "TESTING FOR PCS-2395: Allow inbound TCP DNS traffic from the regional hub to port 53"
+    name                       = "AllowDNSTcpInbound"
+    description                = "Allow inbound TCP DNS traffic from any source to port 53"
     priority                   = 111
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "53"
-    source_address_prefix      = data.azurerm_virtual_hub.vwan_hub.address_prefix
+    source_address_prefix      = "*"
     destination_address_prefix = "VirtualNetwork"
   }
 


### PR DESCRIPTION
## Summary
- Widen inbound DNS Private Resolver NSG rules from the regional hub prefix to any source for TCP/UDP port 53
- Rename rules to `AllowDNSUdpInbound` / `AllowDNSTcpInbound` and refresh module docs

## Test plan
- [ ] Review `terraform plan` in the private DNS consumer for NSG rule replace/update on the inbound endpoint NSG
- [ ] Confirm inbound resolver DNS queries succeed from expected sources after apply
- [ ] Confirm non-DNS inbound/outbound traffic remains denied by the existing deny rules