### PR TITLE
Disable Key Vault integrated CA in Enforce-GR-KeyVault

### DIFF
--- a/caf_cccs_medium/modules/core/README.md
+++ b/caf_cccs_medium/modules/core/README.md
@@ -4,31 +4,31 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.116.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.116.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_alz"></a> [alz](#module\_alz) | Azure/caf-enterprise-scale/azurerm | 6.3.1 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/data-sources/client_config) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_VNet-DNS-Settings"></a> [VNet-DNS-Settings](#input\_VNet-DNS-Settings) | Sets the VNet DNS settings for the policy assignment. | `list(any)` | n/a | yes |
 | <a name="input_aks_security_best_prac_parameters"></a> [aks\_security\_best\_prac\_parameters](#input\_aks\_security\_best\_prac\_parameters) | Parameter values for the AKS-Security-BestPrac initiative assignment. | <pre>object({<br/>    enforce_azure_cni_overlay    = string<br/>    enforce_entra_id_integration = string<br/>    enforce_kubernetes_rbac      = string<br/>    enforce_azure_rbac           = string<br/>    enforce_disable_local_auth   = string<br/>    enforce_workload_identity    = string<br/>    enforce_managed_identity     = string<br/>    enforce_oidc_issuer          = string<br/>    enforce_secrets_store_csi    = string<br/>    enforce_acns_security        = string<br/>    enforce_cilium_dataplane     = string<br/>    audit_azure_policy_addon     = string<br/>    deploy_azure_policy_addon    = string<br/>    deploy_image_cleaner         = string<br/>    audit_image_cleaner          = string<br/>  })</pre> | n/a | yes |
 | <a name="input_configure_connectivity_resources"></a> [configure\_connectivity\_resources](#input\_configure\_connectivity\_resources) | Configuration settings for "connectivity" resources. | `any` | n/a | yes |

--- a/caf_cccs_medium/modules/core/settings.core.tf
+++ b/caf_cccs_medium/modules/core/settings.core.tf
@@ -56,6 +56,15 @@ locals {
         }
       }
     }
+    platform = {
+      parameters = {
+        # Built-in CAF assignment; DigiCert/GlobalSign-only integrated CA is unused, so disable that effect.
+        Enforce-GR-KeyVault = {
+          keyVaultIntegratedCa = "Disabled"
+        }
+      }
+      access_control = {}
+    }
     landing-zones = {
       parameters = {
         Resource-Locations = {
@@ -92,7 +101,11 @@ locals {
         Deny-Azure-SRE-Agent   = var.deny_azure_sre_agent_parameters,
         Deny-Fabric-Capacity   = var.deny_fabric_capacity_parameters,
         Deny-Power-Platform    = var.deny_power_platform_parameters,
-        Deny-Azure-AI-Services = var.deny_azure_ai_services_parameters
+        Deny-Azure-AI-Services = var.deny_azure_ai_services_parameters,
+        # Built-in CAF assignment; DigiCert/GlobalSign-only integrated CA is unused, so disable that effect.
+        Enforce-GR-KeyVault = {
+          keyVaultIntegratedCa = "Disabled"
+        }
       }
       access_control = {}
     }


### PR DESCRIPTION
## Summary
- Set `keyVaultIntegratedCa` to `Disabled` on the built-in CAF `Enforce-GR-KeyVault` assignment for `platform` and `landing-zones`.
- Leave `keyVaultIntegratedCaValue` unchanged so DigiCert/GlobalSign defaults remain.
- Avoids enforcing DigiCert/GlobalSign-only integrated CA when that feature is unused.

## Test plan
- [ ] Apply via azure-lz-core-forge/caf and confirm `Enforce-GR-KeyVault` updates successfully
- [ ] Verify assignment parameters show `keyVaultIntegratedCa=Disabled` and `keyVaultIntegratedCaValue` still DigiCert/GlobalSign
- [ ] Confirm existing Key Vault certificate workflows are unaffected