### PR TITLE
Update cost recovery script

### DIFF
--- a/cost-recovery/README.md
+++ b/cost-recovery/README.md
@@ -12,6 +12,8 @@ This script queries Azure Cost Management API to generate detailed cost recovery
 - Supports custom date ranges and granularity
 - Optionally includes decommissioned management group data
 - Excel output is formatted for readability
+- Automatically retries with exponential backoff if Azure Cost Management rate-limits a request
+- Optional Monthly Spend Report: Avg/Last/Peak monthly spend and a Variability classification (Stable/Variable/Burst-Seasonal/Dormant) per project, optionally enriched with project metadata from a Registry export CSV
 
 ## Prerequisites
 
@@ -31,15 +33,39 @@ python cost_recovery.py -m 3
 ### Options
 
 - `-m, --months`: Number of previous months to include (default: 1)
-- `--mgmt-group-live`: Name of the live landing zones management group (default: bcgov-managed-lz-live-landing-zones)
-- `--mgmt-group-decom`: Name of the decommissioned management group (default: bcgov-managed-lz-decommissioned)
+- `--mgmt-group`: Starting management group ID for hierarchy traversal (default: bcgov-managed-lz-live-landing-zones)
+- `--mgmt-group-decom`: Name of the decommissioned management group (default: bcgov-managed-lz-live-decommissioned)
 - `--include-decom`: Include the decommissioned management group in the cost recovery report
-- `--granularity`: Granularity of the cost report (choices: Daily, Monthly, None; default: Monthly)
+- `--granularity`: Granularity of the cost report (choices: Daily, Monthly; default: Monthly)
 - `--output-prefix`: Prefix for output files (default: azure_cost_recovery)
 - `--start-date`: Custom start date for the report period (YYYY-MM-DD). Overrides --months if set.
 - `--end-date`: Custom end date for the report period (YYYY-MM-DD). Overrides --months if set.
+- `--monthly-spend-report`: Generate the Monthly Spend Report (see below) alongside the Cost Recovery report. Requires `--granularity Monthly`.
+- `--registry-csv`: Path to a Registry export CSV (e.g. `public-cloud-products.csv`) used to enrich the Monthly Spend Report with project metadata (Project Name, Description, PO, Creation Date). Implies `--monthly-spend-report`.
 
-> **Recommendation:** For most use cases, use the default `Monthly` granularity. This provides a clear, summarized view of costs and is suitable for reporting and reconciliation. Daily granularity is only recommended for detailed analysis or troubleshooting specific cost spikes.
+> **Recommendation:** For most use cases, use the default `Monthly` granularity. This provides a clear, summarized view of costs and is suitable for reporting and reconciliation. Daily granularity is only recommended for detailed analysis or troubleshooting specific cost spikes, and is not compatible with `--monthly-spend-report`/`--registry-csv`.
+
+## Monthly Spend Report
+
+A single "current monthly spend" figure can be misleading for consumption-based cloud costs (spikes, seasonality, idle periods, growth/decline). The Monthly Spend Report instead reports the following metrics (grouped by icense plate across all of its subscriptions):
+
+- **Avg Monthly Spend**, **Last Month Spend**, **Peak Month Spend** — Calculated from complete billing months present in the data
+- **Variability** — A 'Coefficient of Variation'-based classification: `Stable`, `Variable`, `Burst / Seasonal`, or `Dormant` (most recent 3 months all under $1 CAD)
+- **EA** (Expense Authority) — rolled up from the existing subscription tag; left blank if untagged
+- Project metadata (**Project Name**, **Description**, **PO**, **Project Creation Date**) when `--registry-csv` is supplied; blank otherwise
+
+Generate it with either flag:
+
+```bash
+# Azure spend metrics only, no project metadata
+python cost_recovery.py -m 12 --monthly-spend-report
+
+# Spend metrics enriched with project metadata from the Registry
+python cost_recovery.py -m 12 --registry-csv ./public-cloud-products.csv
+```
+
+**Tip:**
+Use a longer `-m`/`--months` window (6-12+) for meaningful Variability results — with only 1-2 months of history, dormant projects can never be detected, and Variability will always show 'Stable'.
 
 ### Example
 
@@ -60,6 +86,7 @@ python cost_recovery.py --start-date 2024-01-01 --end-date 2024-03-31 --output-p
 - **Detail CSV**: Subscription-level cost details (e.g., `azure_cost_recovery_detail_2024-01-01_to_2024-03-31.csv`)
 - **Summary CSV**: Grouped and calculated summary (e.g., `azure_cost_recovery_report_2024-01-01_to_2024-03-31.csv`)
 - **Summary Excel**: Formatted Excel file with summary (e.g., `azure_cost_recovery_report_2024-01-01_to_2024-03-31.xlsx`)
+- **Monthly Spend Report CSV/Excel** (when `--monthly-spend-report` or `--registry-csv` is used): e.g., `azure_cost_recovery_monthly_spend_2024-01-01_to_2024-03-31.csv` / `.xlsx`
 
 The Excel output includes bold headers, column width adjustments, money formatting, and frozen header row for easier review.
 

--- a/cost-recovery/README.md
+++ b/cost-recovery/README.md
@@ -47,7 +47,7 @@ python cost_recovery.py -m 3
 
 ## Monthly Spend Report
 
-A single "current monthly spend" figure can be misleading for consumption-based cloud costs (spikes, seasonality, idle periods, growth/decline). The Monthly Spend Report instead reports the following metrics (grouped by icense plate across all of its subscriptions):
+A single "current monthly spend" figure can be misleading for consumption-based cloud costs (spikes, seasonality, idle periods, growth/decline). The Monthly Spend Report instead reports the following metrics (grouped by license plate across all of its subscriptions):
 
 - **Avg Monthly Spend**, **Last Month Spend**, **Peak Month Spend** — Calculated from complete billing months present in the data
 - **Variability** — A 'Coefficient of Variation'-based classification: `Stable`, `Variable`, `Burst / Seasonal`, or `Dormant` (most recent 3 months all under $1 CAD)

--- a/cost-recovery/cost_recovery.py
+++ b/cost-recovery/cost_recovery.py
@@ -275,6 +275,9 @@ def load_registry_csv(registry_csv_path):
 
 
 def aggregate_project_monthly_costs(cost_detail_df):
+    """
+    Roll subscription-level monthly costs up to project-level monthly totals.
+    """
     if cost_detail_df.empty:
         return pd.DataFrame(columns=["LicensePlate", "Date", "Cost"])
 
@@ -299,8 +302,9 @@ def resolve_project_expense_authority(cost_detail_df):
 
 def compute_project_spend_metrics(project_monthly_df):
     """
-    Compute Avg/Last/Peak monthly spend and Coefficient of Variation based classification per project,
-    using only actual months present in the export (never assume $0 for months with no data).
+    Compute Avg/Last/Peak monthly spend and Coefficient of Variation-based
+    classification per project, using only actual months present in the
+    export (never assume $0 for months with no data).
     """
     metrics = []
     for license_plate, group in project_monthly_df.groupby("LicensePlate"):
@@ -308,7 +312,8 @@ def compute_project_spend_metrics(project_monthly_df):
         if not monthly_costs:
             continue
 
-        # A $0.00 first month is almost always a partial billing period, not real spend, so we can exclude it from metrics.
+        # A $0.00 first month is almost always a partial billing period,
+        # not real spend, so we can exclude it from metrics.
         stats_costs = monthly_costs
         if len(monthly_costs) > 1 and round(monthly_costs[0], 2) == 0.00:
             print(f"Info: [{license_plate}] excluding $0.00 first month from statistics (first-month-zero rule).")
@@ -328,7 +333,7 @@ def compute_project_spend_metrics(project_monthly_df):
 
         cv = (std_dev / avg_monthly_spend) if avg_monthly_spend else 0.0
 
-        # Variability Classification: First check if the project is Dormant. 
+        # Variability Classification: First check if the project is Dormant.
         # Otherwise, Stable / Variable / Burst are selected based on the CV.
         last_three_months = monthly_costs[-3:]
         if len(last_three_months) == 3 and all(c < 1.0 for c in last_three_months):
@@ -341,8 +346,9 @@ def compute_project_spend_metrics(project_monthly_df):
             classification = "Burst / Seasonal"
 
         print(
-            f"Info: [{license_plate}] months={included_months} avg=${avg_monthly_spend:.2f} "
-            f"last=${last_month_spend:.2f} peak=${peak_month_spend:.2f} cv={cv:.2f} -> {classification}"
+            f"Info: [{license_plate}] months={included_months} "
+            f"avg=${avg_monthly_spend:.2f} last=${last_month_spend:.2f} "
+            f"peak=${peak_month_spend:.2f} cv={cv:.2f} -> {classification}"
         )
 
         metrics.append(
@@ -361,7 +367,8 @@ def compute_project_spend_metrics(project_monthly_df):
 
 def build_monthly_spend_report(cost_detail_df, registry_df, platform="Azure"):
     """
-    Build the Monthly Spend Report by joining project-level spend statistics with Registry export metadata on License Plate. 
+    Build the Monthly Spend Report by joining project-level spend statistics
+    with Registry export metadata on License Plate.
     """
     project_monthly = aggregate_project_monthly_costs(cost_detail_df)
     spend_metrics = compute_project_spend_metrics(project_monthly)
@@ -522,7 +529,8 @@ if __name__ == "__main__":
         # Combine the results
         df = pd.concat(dfs, ignore_index=True)
 
-        # Create summary by account coding with tax calculations (repeat logic from get_subscription_costs)
+        # Create summary by account coding with tax calculations
+        # (repeat logic from get_subscription_costs)
         summary_df = (
             df.groupby(["AccountCoding", "ExpenseAuthority"])
             .agg(

--- a/cost-recovery/cost_recovery.py
+++ b/cost-recovery/cost_recovery.py
@@ -115,32 +115,29 @@ def get_subscription_costs(
 
         df = pd.DataFrame(cost_data)
 
-        # Get subscription tags
+        # Get subscription tags. Tags are a property of the subscription,
+        # so fetch values for each unique subscription once and cache them
+        # instead of re-fetching for every row in the DataFrame.
         print("\nFetching subscription tags...")
-        for index, row in df.iterrows():
+        tag_cache = {}
+        for sub_id in df["SubscriptionId"].unique():
             try:
-                sub_scope=f"/subscriptions/{row['SubscriptionId']}"
-                tag_details = resource_client.tags.get_at_scope(sub_scope)
-                tags = (tag_details.properties.tags
-                        if tag_details and tag_details.properties
-                        else {}
+                tag_details = resource_client.tags.get_at_scope(f"/subscriptions/{sub_id}")
+                tags = (
+                    tag_details.properties.tags
+                    if tag_details and tag_details.properties
+                    else {}
                 )
-                df.at[index, "AccountCoding"] = (
-                    tags.get("account_coding", "Untagged")
-                    if tags
-                    else "Untagged"
-                )
-                df.at[index, "ExpenseAuthority"] = (
-                    tags.get("expense_authority", "Untagged")
-                    if tags
-                    else "Untagged"
-                )
+                tag_cache[sub_id] = {
+                    "AccountCoding": tags.get("account_coding", "Untagged") if tags else "Untagged",
+                    "ExpenseAuthority": tags.get("expense_authority", "Untagged") if tags else "Untagged",
+                }
             except Exception as e:
-                print(
-                    f"Warning: Could not fetch tags for subscription {row['SubscriptionId']}: {str(e)}"
-                )
-                df.at[index, "AccountCoding"] = "Untagged"
-                df.at[index, "ExpenseAuthority"] = "Untagged"
+                print(f"Warning: Could not fetch tags for subscription {sub_id}: {str(e)}")
+                tag_cache[sub_id] = {"AccountCoding": "Untagged", "ExpenseAuthority": "Untagged"}
+
+        df["AccountCoding"] = df["SubscriptionId"].map(lambda sub_id: tag_cache[sub_id]["AccountCoding"])
+        df["ExpenseAuthority"] = df["SubscriptionId"].map(lambda sub_id: tag_cache[sub_id]["ExpenseAuthority"])
 
         # Create summary by account coding with tax calculations
         summary_df = (

--- a/cost-recovery/cost_recovery.py
+++ b/cost-recovery/cost_recovery.py
@@ -8,6 +8,15 @@ from azure.mgmt.resource import ResourceManagementClient
 from dateutil.relativedelta import relativedelta
 
 
+# ---------------------------------------------------------------------------
+# Cost Recovery Report
+#
+# Queries Azure Cost Management for actual subscription costs, tags each
+# subscription with its Account Coding / Expense Authority, and rolls up
+# costs into a chargeback summary with PST and brokerage fees applied.
+# ---------------------------------------------------------------------------
+
+
 def get_subscription_costs(
     management_group_id: str,
     start_date: str,
@@ -191,6 +200,196 @@ def get_subscription_costs(
         raise
 
 
+# -----------------------------------------------------------------------------
+# Monthly Spend Report
+#
+# This report generates Avg/Last Month/Peak monthly spend plus a Coefficient-
+# of-Variation (CV) based "Variability" classification, optionally adding
+# project metadata from a Registry export CSV (e.g. public-cloud-products.csv).
+#
+# -----------------------------------------------------------------------------
+
+REGISTRY_FIELD_ALIASES = {
+    "LicensePlate": ["licence plate", "license plate"],
+    "ProjectName": ["name", "project name"],
+    "Description": ["description"],
+    "ReasonDescription": [
+        "description of selected reasons",
+        "description of reasons for selecting cloud",
+    ],
+    "ProjectOwnerName": ["project owner name", "project owner"],
+    "CreateDate": ["create date", "created date"],
+}
+
+
+def load_registry_csv(registry_csv_path):
+    """
+    Load a Registry export CSV and normalize its headers to canonical field names. 
+    Returns an empty DataFrame if the file is missing so that the Monthly Spend Report
+    can still be produced from Azure cost data alone.
+    """
+    try:
+        registry_df = pd.read_csv(registry_csv_path, dtype=str)
+    except Exception as e:
+        print(f"Warning: Could not read Registry CSV '{registry_csv_path}': {e}")
+        return pd.DataFrame(columns=list(REGISTRY_FIELD_ALIASES.keys()))
+
+    normalized_headers = {col.strip().lower(): col for col in registry_df.columns}
+
+    clean = pd.DataFrame()
+    for canonical_name, aliases in REGISTRY_FIELD_ALIASES.items():
+        source_col = next((normalized_headers[a] for a in aliases if a in normalized_headers), None)
+        clean[canonical_name] = registry_df[source_col] if source_col is not None else ""
+
+    if (clean["LicensePlate"] == "").all():
+        print(
+            f"Warning: Registry CSV '{registry_csv_path}' has no recognizable 'License plate' "
+            "column; project metadata cannot be joined to Azure costs."
+        )
+
+    # Licence plate is the authoritative join key; normalize case/whitespace before joining.
+    clean["LicensePlate"] = clean["LicensePlate"].astype(str).str.strip().str.lower()
+    clean = clean[clean["LicensePlate"] != ""]
+    clean = clean.drop_duplicates(subset="LicensePlate", keep="first")
+    return clean
+
+
+def aggregate_project_monthly_costs(cost_detail_df):
+    if cost_detail_df.empty:
+        return pd.DataFrame(columns=["LicensePlate", "Date", "Cost"])
+
+    monthly = cost_detail_df.groupby(["LicensePlate", "Date"], as_index=False)["Cost"].sum()
+    return monthly.sort_values(["LicensePlate", "Date"])
+
+
+def _tagged_expense_authority(values):
+    return next((v for v in values if v and v != "Untagged"), "")
+
+
+def resolve_project_expense_authority(cost_detail_df):
+    """
+    Roll up subscription-level Expense Authority tags to one value per project License Plate.
+    """
+    if cost_detail_df.empty or "ExpenseAuthority" not in cost_detail_df.columns:
+        return pd.DataFrame(columns=["LicensePlate", "ExpenseAuthority"])
+
+    result = cost_detail_df.groupby("LicensePlate")["ExpenseAuthority"].apply(_tagged_expense_authority)
+    return result.reset_index()
+
+
+def compute_project_spend_metrics(project_monthly_df):
+    """
+    Compute Avg/Last/Peak monthly spend and Coefficient of Variation based classification per project,
+    using only actual months present in the export (never assume $0 for months with no data).
+    """
+    metrics = []
+    for license_plate, group in project_monthly_df.groupby("LicensePlate"):
+        monthly_costs = group.sort_values("Date")["Cost"].tolist()
+        if not monthly_costs:
+            continue
+
+        # A $0.00 first month is almost always a partial billing period, not real spend, so we can exclude it from metrics.
+        stats_costs = monthly_costs
+        if len(monthly_costs) > 1 and round(monthly_costs[0], 2) == 0.00:
+            print(f"Info: [{license_plate}] excluding $0.00 first month from statistics (first-month-zero rule).")
+            stats_costs = monthly_costs[1:]
+
+        included_months = len(stats_costs)
+        avg_monthly_spend = sum(stats_costs) / included_months
+        last_month_spend = monthly_costs[-1]
+        peak_month_spend = max(monthly_costs)
+
+        if included_months > 1:
+            variance = sum((c - avg_monthly_spend) ** 2 for c in stats_costs) / included_months
+            std_dev = variance ** 0.5
+        else:
+            std_dev = 0.0
+            print(f"Info: [{license_plate}] only a single month of history is available; variability is not meaningful.")
+
+        cv = (std_dev / avg_monthly_spend) if avg_monthly_spend else 0.0
+
+        # Variability Classification: First check if the project is Dormant. 
+        # Otherwise, Stable / Variable / Burst are selected based on the CV.
+        last_three_months = monthly_costs[-3:]
+        if len(last_three_months) == 3 and all(c < 1.0 for c in last_three_months):
+            classification = "Dormant"
+        elif cv < 0.5:
+            classification = "Stable"
+        elif cv <= 1.5:
+            classification = "Variable"
+        else:
+            classification = "Burst / Seasonal"
+
+        print(
+            f"Info: [{license_plate}] months={included_months} avg=${avg_monthly_spend:.2f} "
+            f"last=${last_month_spend:.2f} peak=${peak_month_spend:.2f} cv={cv:.2f} -> {classification}"
+        )
+
+        metrics.append(
+            {
+                "LicensePlate": license_plate,
+                "AvgMonthlySpend": round(avg_monthly_spend, 2),
+                "LastMonthSpend": round(last_month_spend, 2),
+                "PeakMonthSpend": round(peak_month_spend, 2),
+                "CoefficientOfVariation": round(cv, 4),
+                "Variability": classification,
+            }
+        )
+
+    return pd.DataFrame(metrics)
+
+
+def build_monthly_spend_report(cost_detail_df, registry_df, platform="Azure"):
+    """
+    Build the Monthly Spend Report by joining project-level spend statistics with Registry export metadata on License Plate. 
+    """
+    project_monthly = aggregate_project_monthly_costs(cost_detail_df)
+    spend_metrics = compute_project_spend_metrics(project_monthly)
+    ea_by_project = resolve_project_expense_authority(cost_detail_df)
+
+    if spend_metrics.empty:
+        print("Warning: no Azure cost data available; Monthly Spend Report will only include Registry metadata.")
+    if registry_df.empty:
+        print("Warning: no Registry data available; Monthly Spend Report will only include Azure spend metrics.")
+
+    report = pd.merge(spend_metrics, ea_by_project, on="LicensePlate", how="outer")
+    report = pd.merge(report, registry_df, on="LicensePlate", how="outer", indicator=True)
+
+    # Warn if projects are missing data after the join instead of silently dropping rows
+    azure_only = sorted(report.loc[report["_merge"] == "left_only", "LicensePlate"].tolist())
+    registry_only = sorted(report.loc[report["_merge"] == "right_only", "LicensePlate"].tolist())
+    if azure_only:
+        print(f"Warning: {len(azure_only)} project(s) have Azure cost data but no Registry record: {azure_only}")
+    if registry_only:
+        print(f"Warning: {len(registry_only)} Registry record(s) have no matching Azure cost data: {registry_only}")
+    report = report.drop(columns=["_merge"])
+
+    report["Platform"] = platform
+    report = report.fillna("")
+
+    column_map = {
+        "Platform": "Platform",
+        "LicensePlate": "License Plate",
+        "ProjectName": "Project Name",
+        "Description": "Description",
+        "ReasonDescription": "Description of Reasons for Selecting Cloud",
+        "ProjectOwnerName": "PO",
+        "ExpenseAuthority": "EA",
+        "CreateDate": "Project Creation Date",
+        "AvgMonthlySpend": "Avg Monthly Spend",
+        "LastMonthSpend": "Last Month Spend",
+        "PeakMonthSpend": "Peak Month Spend",
+        "Variability": "Variability",
+        "CoefficientOfVariation": "Variability (CV)",
+    }
+    for source_col in column_map:
+        if source_col not in report.columns:
+            report[source_col] = ""
+
+    report = report.rename(columns=column_map)[list(column_map.values())]
+    return report.sort_values("Project Name").reset_index(drop=True)
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -239,13 +438,33 @@ if __name__ == "__main__":
         "--start-date",
         type=str,
         default=None,
-        help="Custom start date for the report period (YYYY-MM-DD). Overrides --months if set.",
+        help="Custom start date for the report period (YYYY-MM-DD). Overrides `--months` if set.",
     )
     parser.add_argument(
         "--end-date",
         type=str,
         default=None,
-        help="Custom end date for the report period (YYYY-MM-DD). Overrides --months if set.",
+        help="Custom end date for the report period (YYYY-MM-DD). Overrides `--months` if set.",
+    )
+    parser.add_argument(
+        "--monthly-spend-report",
+        dest="monthly_spend_report",
+        action="store_true",
+        help=(
+            "Generate a Monthly Spend Report alongside the Cost Recovery report. "
+            "Can be used with `--registry-csv` to enrich Azure cost data with project metadata. "
+        ),
+    )
+    parser.add_argument(
+        "--registry-csv",
+        dest="registry_csv",
+        type=str,
+        default=None,
+        help=(
+            "Optional: Path to a Registry export CSV file (e.g. './public-cloud-products.csv'). "
+            "Can be used to enrich Azure cost data with project metadata. "
+            "Implies `--monthly-spend-report`."
+        ),
     )
     args = parser.parse_args()
 
@@ -407,6 +626,46 @@ if __name__ == "__main__":
             print(f"  - Detail: {detail_csv}")
             print(f"  - Summary CSV: {summary_csv}")
             print(f"  - Summary Excel: {summary_xlsx}")
+
+        # Avg/Last/Peak/Variability calculations all assume one data point per calendar month
+        monthly_spend_report_requested = args.registry_csv or args.monthly_spend_report
+        if monthly_spend_report_requested and granularity != "Monthly":
+            print(
+                f"\nError: Monthly Spend Report requires '--granularity Monthly', but is set to '{granularity}'. Skipping report."
+            )
+        elif monthly_spend_report_requested:
+            if args.registry_csv:
+                print(f"\nGenerating Monthly Spend Report using registry file: {args.registry_csv}")
+                registry_df = load_registry_csv(args.registry_csv)
+            else:
+                print("\nGenerating Monthly Spend Report from Azure cost data only (no --registry-csv provided)")
+                registry_df = pd.DataFrame(columns=list(REGISTRY_FIELD_ALIASES.keys()))
+            monthly_spend_report = build_monthly_spend_report(df, registry_df)
+
+            if monthly_spend_report.empty:
+                print("No data available to build the Monthly Spend Report (no Azure costs and no Registry records).")
+            else:
+                monthly_spend_csv = f"{output_prefix}_monthly_spend_{start}_to_{end}.csv"
+                monthly_spend_xlsx = f"{output_prefix}_monthly_spend_{start}_to_{end}.xlsx"
+                monthly_spend_report.to_csv(monthly_spend_csv, index=False)
+
+                with pd.ExcelWriter(monthly_spend_xlsx, engine="openpyxl") as writer:
+                    monthly_spend_report.to_excel(writer, sheet_name="Monthly Spend Report", index=False)
+                    worksheet = writer.sheets["Monthly Spend Report"]
+
+                    from openpyxl.styles import Font, PatternFill
+
+                    header_font = Font(bold=True)
+                    header_fill = PatternFill(start_color="D9D9D9", end_color="D9D9D9", fill_type="solid")
+                    for col in range(1, len(monthly_spend_report.columns) + 1):
+                        cell = worksheet.cell(row=1, column=col)
+                        cell.font = header_font
+                        cell.fill = header_fill
+                    worksheet.freeze_panes = "A2"
+
+                print("\nMonthly Spend Report exported to:")
+                print(f"  - CSV: {monthly_spend_csv}")
+                print(f"  - Excel: {monthly_spend_xlsx}")
 
     except Exception as e:
         print(f"\nFailed to retrieve cost data: {str(e)}")

--- a/cost-recovery/cost_recovery.py
+++ b/cost-recovery/cost_recovery.py
@@ -656,7 +656,7 @@ if __name__ == "__main__":
             print(f"  - Summary Excel: {summary_xlsx}")
 
         # Avg/Last/Peak/Variability calculations all assume one data point per calendar month
-        monthly_spend_report_requested = args.registry_csv or args.monthly_spend_report
+        monthly_spend_report_requested = bool(args.registry_csv) or args.monthly_spend_report
         if monthly_spend_report_requested and granularity != "Monthly":
             print(
                 f"\nError: Monthly Spend Report requires '--granularity Monthly', but is set to '{granularity}'. Skipping report."

--- a/cost-recovery/cost_recovery.py
+++ b/cost-recovery/cost_recovery.py
@@ -448,7 +448,7 @@ if __name__ == "__main__":
         "--granularity",
         type=str,
         default="Monthly",
-        choices=["Daily", "Monthly", "None"],
+        choices=["Daily", "Monthly"],
         help="Granularity of the cost report (default: Monthly)",
     )
     parser.add_argument(

--- a/cost-recovery/cost_recovery.py
+++ b/cost-recovery/cost_recovery.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 
@@ -22,6 +23,7 @@ def get_subscription_costs(
     start_date: str,
     end_date: str,
     granularity: str = "Monthly",
+    max_retries: int = 5
 ):
     """
     Query Azure Cost Management for subscription costs within a management group.
@@ -58,17 +60,38 @@ def get_subscription_costs(
         print(f"Scope: {scope}")
         print(f"Query parameters: {query}")
 
-        try:
-            results = cost_client.query.usage(scope=scope, parameters=query)
-            print("\nQuery executed successfully")
-        except Exception as api_error:
-            print("\nAPI Error Details:")
-            print(f"Error type: {type(api_error).__name__}")
-            if hasattr(api_error, "response"):
-                print(f"Response status: {api_error.response.status_code}")
-                print(f"Response headers: {api_error.response.headers}")
-                print(f"Response content: {api_error.response.text}")
-            raise
+        # Cost Management aggressively rate-limits per scope; back off exponentially since the
+        # API's suggested 'retry-after' value is often much shorter than the actual reset window.
+        for attempt in range(1, max_retries + 1):
+            try:
+                results = cost_client.query.usage(scope=scope, parameters=query)
+                print("\nQuery executed successfully")
+                break
+            except Exception as api_error:
+                status_code = getattr(getattr(api_error, "response", None), "status_code", None)
+                if status_code == 429 and attempt < max_retries:
+                    suggested = int(
+                        api_error.response.headers.get(
+                            "x-ms-ratelimit-microsoft.costmanagement-entity-retry-after", 5
+                        )
+                    )
+                    retry_after = min(120, max(suggested, 5) * (2 ** (attempt - 1)))
+                    remaining = api_error.response.headers.get(
+                        "x-ms-ratelimit-remaining-microsoft.costmanagement-entity-requests", "unknown"
+                    )
+                    print(
+                        f"Rate limited (HTTP 429, quota remaining: {remaining}); "
+                        f"retrying in {retry_after}s (attempt {attempt}/{max_retries})..."
+                    )
+                    time.sleep(retry_after)
+                    continue
+                print("\nAPI Error Details:")
+                print(f"Error type: {type(api_error).__name__}")
+                if hasattr(api_error, "response"):
+                    print(f"Response status: {api_error.response.status_code}")
+                    print(f"Response headers: {api_error.response.headers}")
+                    print(f"Response content: {api_error.response.text}")
+                raise
 
         # Process results into DataFrame
         cost_data = []


### PR DESCRIPTION
Introduces improvements to the Azure Cost Recovery script and adds new reporting capabilities.

**New Report Feature:**
* Added a Monthly Spend Report that calculates average, last, and peak monthly spend, as well as a variability classification (Stable/Variable/Burst-Seasonal/Dormant) for each project. This report can be optionally enriched with project metadata from a Registry export CSV. [[1]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698R223-R419) [[2]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698R658-R697)
* Introduced new command-line options: `--monthly-spend-report` to generate the new report, and `--registry-csv` to enrich it with project metadata. The tool validates that monthly granularity is used when generating this report. [[1]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698L242-R494) [[2]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698R658-R697)

**Reliability and Performance:**
* The script now automatically retries Azure Cost Management API requests with exponential backoff when rate-limited (HTTP 429), improving resilience against transient failures. [[1]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698R1) [[2]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698R63-R87)
* Optimized subscription tag fetching by caching tags per unique subscription to reduce redundant ARM API calls and improve performance.

**Minor Changes:**
* Cleaned up CLI argument handling and improved help messages for clarity and consistency. [[1]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698L229-R455) [[2]](diffhunk://#diff-2b088ccff9aeb73aec2c0f53d2b85cb42ee2c6b2d218255a97f255283334a698L242-R494)
* Updated `README.md` to document the retry logic, Monthly Spend Report, changed CLI options, and structure of the new output files. [[1]](diffhunk://#diff-72c3bbc331e557604ff6b32d43860dcac4bc368abe9a2e295155e0c2c804c7dbR15-R16) [[2]](diffhunk://#diff-72c3bbc331e557604ff6b32d43860dcac4bc368abe9a2e295155e0c2c804c7dbL34-R68) [[3]](diffhunk://#diff-72c3bbc331e557604ff6b32d43860dcac4bc368abe9a2e295155e0c2c804c7dbR89)
